### PR TITLE
[Feat]  entity 생성

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+POSTGRES_DB=connecteamed
+POSTGRES_USER=connecteamed
+POSTGRES_PASSWORD=your_secure_password_here
+

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
   implementation 'org.flywaydb:flyway-core'
   runtimeOnly 'org.flywaydb:flyway-database-postgresql'
 
+  // Environment Variables (.env)
+  implementation 'io.github.cdimascio:dotenv-java:3.0.0'
+
   //Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,9 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.connected'
+group = 'com.connecteamed.server'
 version = '0.0.1-SNAPSHOT'
-description = 'Connected Backend API'
+description = 'Connecteamed Backend API'
 
 java {
 	toolchain {

--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 
   // DB Migration (Flyway)
-  implementation 'org.flywaydb:flyway-core'
-  runtimeOnly 'org.flywaydb:flyway-database-postgresql'
+  //implementation 'org.flywaydb:flyway-core'
+  //runtimeOnly 'org.flywaydb:flyway-database-postgresql'
 
   //Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
 services:
   db:
     image: postgres:16
-    container_name: connected-be-db
+    container_name: connecteamed-be-db
     environment:
-      POSTGRES_DB: connected
-      POSTGRES_USER: connected
-      POSTGRES_PASSWORD: connected
+      POSTGRES_DB: connecteamed
+      POSTGRES_USER: connecteamed
+      POSTGRES_PASSWORD: connecteamed
     ports:
       - "5432:5432"
     volumes:
-      - connected-be-db:/var/lib/postgresql/data
+      - connecteamed-be-db:/var/lib/postgresql/data
 
 volumes:
-  connected-be-db:
+  connecteamed-be-db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ services:
     image: postgres:16
     container_name: connecteamed-be-db
     environment:
-      POSTGRES_DB: connecteamed
-      POSTGRES_USER: connecteamed
-      POSTGRES_PASSWORD: connecteamed
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
       - "5432:5432"
     volumes:

--- a/src/main/java/com/connecteamed/server/ConnecteamedApplication.java
+++ b/src/main/java/com/connecteamed/server/ConnecteamedApplication.java
@@ -1,13 +1,14 @@
-package com.connected.be;
+package com.connecteamed.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class ConnectedBeApplication {
+public class ConnecteamedApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(ConnectedBeApplication.class, args);
+		SpringApplication.run(ConnecteamedApplication.class, args);
 	}
 
 }
+

--- a/src/main/java/com/connecteamed/server/ConnecteamedApplication.java
+++ b/src/main/java/com/connecteamed/server/ConnecteamedApplication.java
@@ -1,5 +1,6 @@
 package com.connecteamed.server;
 
+import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class ConnecteamedApplication {
 
 	public static void main(String[] args) {
+		Dotenv.load();
 		SpringApplication.run(ConnecteamedApplication.class, args);
 	}
 

--- a/src/main/java/com/connecteamed/server/domain/document/entity/Document.java
+++ b/src/main/java/com/connecteamed/server/domain/document/entity/Document.java
@@ -1,4 +1,59 @@
 package com.connecteamed.server.domain.document.entity;
 
-public class Document {
+import com.connecteamed.server.domain.document.enums.FileType;
+import com.connecteamed.server.domain.project.entity.Project;
+import com.connecteamed.server.domain.project.entity.ProjectMember;
+import com.connecteamed.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+
+@Entity
+@Builder
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@AllArgsConstructor(access= AccessLevel.PRIVATE)
+@Getter
+@Table(name= "document")
+public class Document extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="public_id",nullable = false,unique = true,columnDefinition = "UUID")
+    private UUID publicId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="project_id",nullable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="project_member_id",nullable = false)
+    private ProjectMember projectMember;
+
+    @Column(name="title",nullable = false)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name="file_type",nullable = false)
+    private FileType fileType;
+
+    @Column(name = "file_url", columnDefinition = "TEXT")
+    private String fileUrl;
+
+    @Column(name="content", columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name="deleted_at")
+    private OffsetDateTime deletedAt;
+
+    @PrePersist
+    public void prePersist(){
+        if(this.publicId == null){
+            this.publicId = UUID.randomUUID();
+        }
+    }
+
 }

--- a/src/main/java/com/connecteamed/server/domain/document/enums/FileType.java
+++ b/src/main/java/com/connecteamed/server/domain/document/enums/FileType.java
@@ -1,0 +1,8 @@
+package com.connecteamed.server.domain.document.enums;
+
+public enum FileType {
+    PDF,
+    DOCX,
+    IMAGE,
+    TEXT
+}

--- a/src/main/java/com/connecteamed/server/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/controller/MeetingController.java
@@ -1,0 +1,4 @@
+package com.connecteamed.server.domain.meeting.controller;
+
+public class MeetingController {
+}

--- a/src/main/java/com/connecteamed/server/domain/meeting/dto/MeetingCreateReq.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/dto/MeetingCreateReq.java
@@ -1,0 +1,4 @@
+package com.connecteamed.server.domain.meeting.dto;
+
+public class MeetingCreateReq {
+}

--- a/src/main/java/com/connecteamed/server/domain/meeting/dto/MeetingRes.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/dto/MeetingRes.java
@@ -1,0 +1,4 @@
+package com.connecteamed.server.domain.meeting.dto;
+
+public class MeetingRes {
+}

--- a/src/main/java/com/connecteamed/server/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/entity/Meeting.java
@@ -1,4 +1,45 @@
 package com.connecteamed.server.domain.meeting.entity;
 
-public class Meeting {
+import com.connecteamed.server.domain.project.entity.Project;
+import com.connecteamed.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "meeting")
+public class Meeting extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "public_id", nullable = false, unique = true, columnDefinition = "UUID")
+    private UUID publicId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "meeting_date", nullable = false)
+    private OffsetDateTime meetingDate;
+
+    @Column(name = "deleted_at")
+    private OffsetDateTime deletedAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (this.publicId == null) {
+            this.publicId = UUID.randomUUID();
+        }
+    }
 }

--- a/src/main/java/com/connecteamed/server/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/entity/Meeting.java
@@ -1,0 +1,4 @@
+package com.connecteamed.server.domain.meeting.entity;
+
+public class Meeting {
+}

--- a/src/main/java/com/connecteamed/server/domain/meeting/entity/MeetingAgenda.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/entity/MeetingAgenda.java
@@ -1,5 +1,31 @@
 package com.connecteamed.server.domain.meeting.entity;
 
-public class MeetingAgenda {
+import com.connecteamed.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
 
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "meeting_agenda")
+public class MeetingAgenda extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id", nullable = false)
+    private Meeting meeting;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
 }

--- a/src/main/java/com/connecteamed/server/domain/meeting/entity/MeetingAgenda.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/entity/MeetingAgenda.java
@@ -1,0 +1,5 @@
+package com.connecteamed.server.domain.meeting.entity;
+
+public class MeetingAgenda {
+
+}

--- a/src/main/java/com/connecteamed/server/domain/meeting/entity/MeetingAttendee.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/entity/MeetingAttendee.java
@@ -1,4 +1,35 @@
 package com.connecteamed.server.domain.meeting.entity;
 
-public class MeetingAttendee {
+import com.connecteamed.server.domain.project.entity.ProjectMember;
+import com.connecteamed.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(
+        name = "meeting_attendee",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_meeting_attendee_meeting_member",
+                        columnNames = {"meeting_id", "project_member_id"} // 조합 unique 반영
+                )
+        }
+)
+public class MeetingAttendee extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id", nullable = false)
+    private Meeting meeting;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "attendee_id", nullable = false)
+    private ProjectMember projectMember;
 }

--- a/src/main/java/com/connecteamed/server/domain/meeting/entity/MeetingAttendee.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/entity/MeetingAttendee.java
@@ -15,7 +15,7 @@ import lombok.*;
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_meeting_attendee_meeting_member",
-                        columnNames = {"meeting_id", "project_member_id"} // 조합 unique 반영
+                        columnNames = {"meeting_id", "attendee_id"} // 조합 unique 반영
                 )
         }
 )

--- a/src/main/java/com/connecteamed/server/domain/meeting/entity/MeetingAttendee.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/entity/MeetingAttendee.java
@@ -1,0 +1,4 @@
+package com.connecteamed.server.domain.meeting.entity;
+
+public class MeetingAttendee {
+}

--- a/src/main/java/com/connecteamed/server/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/repository/MeetingRepository.java
@@ -1,0 +1,4 @@
+package com.connecteamed.server.domain.meeting.repository;
+
+public class MeetingRepository {
+}

--- a/src/main/java/com/connecteamed/server/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/service/MeetingService.java
@@ -1,0 +1,4 @@
+package com.connecteamed.server.domain.meeting.service;
+
+public class MeetingService {
+}

--- a/src/main/java/com/connecteamed/server/domain/member/entity/Member.java
+++ b/src/main/java/com/connecteamed/server/domain/member/entity/Member.java
@@ -1,5 +1,57 @@
 package com.connecteamed.server.domain.member.entity;
 
-public class Member {
+
+import com.connecteamed.server.domain.member.enums.SocialType;
+import com.connecteamed.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.util.UUID;
+
+
+@Entity
+@Builder
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@AllArgsConstructor(access= AccessLevel.PRIVATE)
+@Getter
+@Table(name= "member")
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="public_id", nullable = false,unique = true, columnDefinition = "UUID")
+    private UUID publicId;
+
+    @Column(name="name",nullable = false)
+    private String name;
+
+    @Column(name="login_id",unique = true)
+    private String loginId; //소셜 로그인 시 NULL 가능
+
+    @Column(name="password")
+    private String password; //소셜 로그인 시 NULL 가능
+
+    @Enumerated(EnumType.STRING)
+    @Column(name="social_type",nullable = false)
+    private SocialType socialType;
+
+    @Column(name = "deleted_at")
+    private OffsetDateTime deletedAt;
+
+    //객체 생성시에 public_id 자동 생성해주는 빌더
+    @PrePersist
+    public void prePersist(){
+        if(this.publicId == null){
+            this.publicId = UUID.randomUUID();
+        }
+    }
+
+
+
+
 
 }

--- a/src/main/java/com/connecteamed/server/domain/member/entity/Member.java
+++ b/src/main/java/com/connecteamed/server/domain/member/entity/Member.java
@@ -1,4 +1,5 @@
 package com.connecteamed.server.domain.member.entity;
 
 public class Member {
+
 }

--- a/src/main/java/com/connecteamed/server/domain/member/entity/Member.java
+++ b/src/main/java/com/connecteamed/server/domain/member/entity/Member.java
@@ -7,7 +7,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
-import java.time.OffsetTime;
 import java.util.UUID;
 
 

--- a/src/main/java/com/connecteamed/server/domain/member/enums/SocialType.java
+++ b/src/main/java/com/connecteamed/server/domain/member/enums/SocialType.java
@@ -1,0 +1,5 @@
+package com.connecteamed.server.domain.member.enums;
+
+public enum SocialType {
+    LOCAL,GOOGLE,NAVER,KAKAO
+}

--- a/src/main/java/com/connecteamed/server/domain/minute/controller/MinuteController.java
+++ b/src/main/java/com/connecteamed/server/domain/minute/controller/MinuteController.java
@@ -1,4 +1,0 @@
-package com.connecteamed.server.domain.minute.controller;
-
-public class MinuteController {
-}

--- a/src/main/java/com/connecteamed/server/domain/minute/dto/MinuteCreateReq.java
+++ b/src/main/java/com/connecteamed/server/domain/minute/dto/MinuteCreateReq.java
@@ -1,4 +1,0 @@
-package com.connecteamed.server.domain.minute.dto;
-
-public class MinuteCreateReq {
-}

--- a/src/main/java/com/connecteamed/server/domain/minute/dto/MinuteRes.java
+++ b/src/main/java/com/connecteamed/server/domain/minute/dto/MinuteRes.java
@@ -1,4 +1,0 @@
-package com.connecteamed.server.domain.minute.dto;
-
-public class MinuteRes {
-}

--- a/src/main/java/com/connecteamed/server/domain/minute/entity/Agenda.java
+++ b/src/main/java/com/connecteamed/server/domain/minute/entity/Agenda.java
@@ -1,4 +1,0 @@
-package com.connecteamed.server.domain.minute.entity;
-
-public class Agenda {
-}

--- a/src/main/java/com/connecteamed/server/domain/minute/entity/Minute.java
+++ b/src/main/java/com/connecteamed/server/domain/minute/entity/Minute.java
@@ -1,4 +1,0 @@
-package com.connecteamed.server.domain.minute.entity;
-
-public class Minute {
-}

--- a/src/main/java/com/connecteamed/server/domain/minute/repository/MinuteRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/minute/repository/MinuteRepository.java
@@ -1,4 +1,0 @@
-package com.connecteamed.server.domain.minute.repository;
-
-public class MinuteRepository {
-}

--- a/src/main/java/com/connecteamed/server/domain/minute/service/MinuteService.java
+++ b/src/main/java/com/connecteamed/server/domain/minute/service/MinuteService.java
@@ -1,4 +1,0 @@
-package com.connecteamed.server.domain.minute.service;
-
-public class MinuteService {
-}

--- a/src/main/java/com/connecteamed/server/domain/notification/entity/Notification.java
+++ b/src/main/java/com/connecteamed/server/domain/notification/entity/Notification.java
@@ -1,4 +1,46 @@
 package com.connecteamed.server.domain.notification.entity;
 
-public class Notification {
+import com.connecteamed.server.domain.member.entity.Member;
+import com.connecteamed.server.domain.project.entity.Project;
+import com.connecteamed.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "notification")
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false) // 알림 수신자 id
+    private Member receiver;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id") // 발신자 id (시스템 발송일 경우 NULL 허용)
+    private Member sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false) //관련 프로젝트
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notification_type_id", nullable = false) // 알림 타입
+    private NotificationType notificationType;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content; // 백엔드에서 조립된 최종 메시지
+
+    @Column(name = "target_url", nullable = false, columnDefinition = "TEXT")
+    private String targetUrl; // 클릭 시 이동 경로
+
+    @Builder.Default
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead = false;
 }

--- a/src/main/java/com/connecteamed/server/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/connecteamed/server/domain/notification/entity/NotificationType.java
@@ -1,0 +1,4 @@
+package com.connecteamed.server.domain.notification.entity;
+
+public class NotificationType {
+}

--- a/src/main/java/com/connecteamed/server/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/connecteamed/server/domain/notification/entity/NotificationType.java
@@ -1,4 +1,24 @@
 package com.connecteamed.server.domain.notification.entity;
 
-public class NotificationType {
+import com.connecteamed.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "notification_type")
+public class NotificationType extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "type_key", nullable = false, columnDefinition = "TEXT")
+    private String typeKey; // ex TASK_TAGGED, TASK_DONE_SOON
+
+    @Column(name = "display_name", nullable = false, columnDefinition = "TEXT")
+    private String displayName; // ex "업무 태그 알림"
 }

--- a/src/main/java/com/connecteamed/server/domain/project/entity/Project.java
+++ b/src/main/java/com/connecteamed/server/domain/project/entity/Project.java
@@ -1,4 +1,43 @@
 package com.connecteamed.server.domain.project.entity;
 
-public class Project {
+
+import com.connecteamed.server.domain.member.entity.Member;
+import com.connecteamed.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Builder
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@AllArgsConstructor(access= AccessLevel.PRIVATE)
+@Getter
+@Table(name= "project")
+public class Project extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="public_id",nullable = false,unique = true,columnDefinition = "UUID")
+    private UUID publicId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="owner_id",nullable = false)
+    private Member owner;
+
+    @Column(name="name",nullable = false)
+    private String name;
+
+    @Column(name="goal",nullable = false, columnDefinition = "TEXT")
+    private String goal;
+
+    @PrePersist
+    public void prePersist(){
+        if(this.publicId == null){
+            this.publicId = UUID.randomUUID();
+        }
+    }
+
+
 }

--- a/src/main/java/com/connecteamed/server/domain/project/entity/ProjectMember.java
+++ b/src/main/java/com/connecteamed/server/domain/project/entity/ProjectMember.java
@@ -2,6 +2,7 @@ package com.connecteamed.server.domain.project.entity;
 
 
 import com.connecteamed.server.domain.member.entity.Member;
+import com.connecteamed.server.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -19,7 +20,7 @@ uniqueConstraints = {
 )
         }
 )
-public class ProjectMember {
+public class ProjectMember extends BaseEntity {
     @Id
     @GeneratedValue(strategy= GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/connecteamed/server/domain/project/entity/ProjectMember.java
+++ b/src/main/java/com/connecteamed/server/domain/project/entity/ProjectMember.java
@@ -25,11 +25,11 @@ public class ProjectMember {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id")
+    @JoinColumn(name = "project_id",nullable = false)
     private Project project;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
 }

--- a/src/main/java/com/connecteamed/server/domain/project/entity/ProjectMember.java
+++ b/src/main/java/com/connecteamed/server/domain/project/entity/ProjectMember.java
@@ -1,4 +1,35 @@
 package com.connecteamed.server.domain.project.entity;
 
+
+import com.connecteamed.server.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@AllArgsConstructor(access= AccessLevel.PRIVATE)
+@Getter
+@Table(name= "project_member",
+
+uniqueConstraints = {
+@UniqueConstraint(
+        name = "uk_project_member_project_member",
+        columnNames = {"project_id", "member_id"} // 조합 unique 반영
+)
+        }
+)
 public class ProjectMember {
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
 }

--- a/src/main/java/com/connecteamed/server/domain/project/entity/ProjectRequiredRole.java
+++ b/src/main/java/com/connecteamed/server/domain/project/entity/ProjectRequiredRole.java
@@ -1,0 +1,4 @@
+package com.connecteamed.server.domain.project.entity;
+
+public class ProjectRequiredRole {
+}

--- a/src/main/java/com/connecteamed/server/domain/project/entity/ProjectRequiredRole.java
+++ b/src/main/java/com/connecteamed/server/domain/project/entity/ProjectRequiredRole.java
@@ -1,4 +1,27 @@
 package com.connecteamed.server.domain.project.entity;
 
-public class ProjectRequiredRole {
+
+import com.connecteamed.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@AllArgsConstructor(access= AccessLevel.PRIVATE)
+@Getter
+@Table(name= "project_required_role")
+public class ProjectRequiredRole extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id",nullable = false)
+    private ProjectRole projectRole;
+
 }

--- a/src/main/java/com/connecteamed/server/domain/project/entity/ProjectRole.java
+++ b/src/main/java/com/connecteamed/server/domain/project/entity/ProjectRole.java
@@ -1,4 +1,22 @@
 package com.connecteamed.server.domain.project.entity;
 
-public class ProjectRole {
+
+import com.connecteamed.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@AllArgsConstructor(access= AccessLevel.PRIVATE)
+@Getter
+@Table(name= "project_role")
+public class ProjectRole extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="role_name",nullable = false,columnDefinition = "TEXT")
+    private String roleName;
+
 }

--- a/src/main/java/com/connecteamed/server/domain/retrospective/entity/AiRetrospective.java
+++ b/src/main/java/com/connecteamed/server/domain/retrospective/entity/AiRetrospective.java
@@ -1,4 +1,51 @@
 package com.connecteamed.server.domain.retrospective.entity;
 
-public class AiRetrospective {
+
+import com.connecteamed.server.domain.project.entity.Project;
+import com.connecteamed.server.domain.project.entity.ProjectMember;
+import com.connecteamed.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Builder
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@AllArgsConstructor(access= AccessLevel.PRIVATE)
+@Getter
+@Table(name = "ai_retrospective")
+public class AiRetrospective extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "public_id", nullable = false, unique = true, columnDefinition = "UUID")
+    private UUID publicId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id", nullable = false)
+    private ProjectMember writer;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "project_result", nullable = false, columnDefinition = "TEXT")
+    private String projectResult;
+
+    @Column(name = "deleted_at")
+    private OffsetDateTime deletedAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (this.publicId == null) {
+            this.publicId = UUID.randomUUID();
+        }
+    }
 }
+

--- a/src/main/java/com/connecteamed/server/domain/retrospective/entity/RetrospectiveTask.java
+++ b/src/main/java/com/connecteamed/server/domain/retrospective/entity/RetrospectiveTask.java
@@ -1,4 +1,27 @@
 package com.connecteamed.server.domain.retrospective.entity;
 
-public class RetrospectiveTask {
+import com.connecteamed.server.domain.task.entity.Task;
+import com.connecteamed.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "retrospective_task")
+public class RetrospectiveTask extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ai_retrospective_id", nullable = false)
+    private AiRetrospective aiRetrospective;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id", nullable = false)
+    private Task task;
 }

--- a/src/main/java/com/connecteamed/server/domain/retrospective/entity/RetrospectiveTask.java
+++ b/src/main/java/com/connecteamed/server/domain/retrospective/entity/RetrospectiveTask.java
@@ -1,0 +1,4 @@
+package com.connecteamed.server.domain.retrospective.entity;
+
+public class RetrospectiveTask {
+}

--- a/src/main/java/com/connecteamed/server/domain/task/entity/Task.java
+++ b/src/main/java/com/connecteamed/server/domain/task/entity/Task.java
@@ -1,5 +1,58 @@
 package com.connecteamed.server.domain.task.entity;
 
-public class Task {
+import com.connecteamed.server.domain.project.entity.Project;
+import com.connecteamed.server.domain.task.enums.TaskStatus;
+import com.connecteamed.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Builder
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@AllArgsConstructor(access= AccessLevel.PRIVATE)
+@Getter
+@Table(name= "task")
+public class Task extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="public_id",nullable = false,unique = true,columnDefinition = "UUID")
+    private UUID publicId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="project_id",nullable = false)
+    private Project project;
+
+    @Column(name="name",nullable = false)
+    private String name;
+
+    @Column(name="content",nullable = false,columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name="status",nullable = false)
+    @Builder.Default
+    private TaskStatus status=TaskStatus.TODO;
+
+    @Column(name="start_date",nullable = false)
+    private OffsetDateTime startDate;
+
+    @Column(name="due_date",nullable = false)
+    private OffsetDateTime dueDate;
+
+    @Column(name="deleted_at")
+    private OffsetDateTime deletedAt;
+
+    @PrePersist
+    public void prePersist(){
+        if(this.publicId == null){
+            this.publicId = UUID.randomUUID();
+        }
+    }
 
 }

--- a/src/main/java/com/connecteamed/server/domain/task/entity/TaskAssignee.java
+++ b/src/main/java/com/connecteamed/server/domain/task/entity/TaskAssignee.java
@@ -1,4 +1,39 @@
 package com.connecteamed.server.domain.task.entity;
 
-public class TaskAssignee {
+
+import com.connecteamed.server.domain.project.entity.Project;
+import com.connecteamed.server.domain.project.entity.ProjectMember;
+import com.connecteamed.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@AllArgsConstructor(access= AccessLevel.PRIVATE)
+@Getter
+@Table(name= "task_assignee",
+        uniqueConstraints = {
+        @UniqueConstraint(
+                name="uk_task_assignee_task_member",
+                columnNames={"task_id","project_member_id"}
+        )
+        }
+)
+public class TaskAssignee extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="task_id",nullable = false)
+    private Task task;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="project_member_id",nullable = false)
+    private ProjectMember projectMember;
+
+
+
 }

--- a/src/main/java/com/connecteamed/server/domain/task/entity/TaskAssignee.java
+++ b/src/main/java/com/connecteamed/server/domain/task/entity/TaskAssignee.java
@@ -1,4 +1,4 @@
 package com.connecteamed.server.domain.task.entity;
 
-public class TaskStatus {
+public class TaskAssignee {
 }

--- a/src/main/java/com/connecteamed/server/domain/task/entity/TaskNote.java
+++ b/src/main/java/com/connecteamed/server/domain/task/entity/TaskNote.java
@@ -1,5 +1,4 @@
 package com.connecteamed.server.domain.task.entity;
 
-public class Task {
-
+public class TaskNote {
 }

--- a/src/main/java/com/connecteamed/server/domain/task/entity/TaskNote.java
+++ b/src/main/java/com/connecteamed/server/domain/task/entity/TaskNote.java
@@ -1,4 +1,29 @@
 package com.connecteamed.server.domain.task.entity;
 
-public class TaskNote {
+
+import com.connecteamed.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@AllArgsConstructor(access= AccessLevel.PRIVATE)
+@Getter
+@Table(name="task_note")
+public class TaskNote extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id", nullable = false)
+    private Task task;
+
+    @OneToOne(fetch =FetchType.LAZY)
+    @JoinColumn(name="task_assignee_id",nullable = false,unique = true)
+    private TaskAssignee taskAssignee;
+
+    @Column(name="content",nullable = false,columnDefinition = "TEXT")
+    private String content;
 }

--- a/src/main/java/com/connecteamed/server/domain/task/enums/TaskStatus.java
+++ b/src/main/java/com/connecteamed/server/domain/task/enums/TaskStatus.java
@@ -1,0 +1,5 @@
+package com.connecteamed.server.domain.task.enums;
+
+public enum TaskStatus {
+    TODO,IN_PROGRESS,DONE
+}

--- a/src/main/java/com/connecteamed/server/global/common/BaseEntity.java
+++ b/src/main/java/com/connecteamed/server/global/common/BaseEntity.java
@@ -1,4 +1,0 @@
-package com.connecteamed.server.global.common;
-
-public class BaseEntity {
-}

--- a/src/main/java/com/connecteamed/server/global/entity/BaseEntity.java
+++ b/src/main/java/com/connecteamed/server/global/entity/BaseEntity.java
@@ -1,0 +1,27 @@
+package com.connecteamed.server.global.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.OffsetDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name="created_at",nullable = false)
+    private OffsetDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name="updated_at")
+    private OffsetDateTime updatedAt;
+
+}

--- a/src/main/java/com/connected/be/ConnectedBeApplication.java
+++ b/src/main/java/com/connected/be/ConnectedBeApplication.java
@@ -2,8 +2,12 @@ package com.connected.be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EntityScan(basePackages = "com.connecteamed.server")
+@EnableJpaAuditing
 public class ConnectedBeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
     open-in-view: false
 
 server:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,11 +1,11 @@
 spring:
   application:
-    name: connected-be
+    name: connecteamed-be
 
   datasource:
-    url: ${DB_URL:jdbc:postgresql://localhost:5432/connected}
-    username: ${DB_USERNAME:connected}
-    password: ${DB_PASSWORD:connected}
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/connecteamed}
+    username: ${DB_USERNAME:connecteamed}
+    password: ${DB_PASSWORD:connecteamed}
     driver-class-name: org.postgresql.Driver
 
   jpa:

--- a/src/test/java/com/connecteamed/server/ConnectedBeApplicationTests.java
+++ b/src/test/java/com/connecteamed/server/ConnectedBeApplicationTests.java
@@ -1,4 +1,4 @@
-package com.connected.be;
+package com.connecteamed.server;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,3 +11,4 @@ class ConnectedBeApplicationTests {
 	}
 
 }
+


### PR DESCRIPTION
## 📌 PR 요약
- 엔티티 설계 및 생성 작업을 완료하고, 로컬 개발을 위한 DB 관련 설정들을 추가하였습니다

## 🔧 변경 사항
- 엔티티 구현: 연관관계는 우선은 단방향 매핑으로만 구현해 두었습니다.
- DB 설정 : 데이터 베이스 연결 환경 구성
- 네이밍 수정: 가독성을 위해 ERD 상의 일부 테이블 및 컬럼명을 수정하였습니다.
## 📋 작업 상세 내용
- [x] Base Entity 구현
           Base_Entity에는 created_at과 updated_at컬럼을 추가하고 @EnableJpaAuditing을 통해 생성일(created_at)과 수정일(updated_at)이 자동 기록되도록 하였습니다.
- [x] Entity 구현
        -erdcloud에서는 테이블 컬럼들을 구상할때 일부 테이블들만 생성일과 수정일을 가지도록 설계했었는데 모든 테이블이 생성일과 수정일을 컬럼으로 가지는 게 나아보여서 구현할 때 모든 테이블이 Base Entity를 상속 받게 코드 작성해 두었습니다(이로인해 created_at과 updated_at가 추가된 테이블의 변경사항은 아직 erd cloud에 반영되지 않은 상태입니다)
       -현재 단방향 매핑으로만 구현이 된 상태인데 나중에 양방향 매핑이 필요하면 추가해서 사용하시면 될 것 같습니다!

- [x] DB 관련 설정
         SQL 로그 관련 설정을 추가해서 콘솔에서 실행 쿼리를 확인할 수 있게 설정해 두었습니다.
또, Flyway 관련 설정을 현재 주석 처리해둔 상태입니다. 개발 초기에는 ddl-auto: update 방식을 사용하고, 만약 DB 구조가 꼬였을 때 개별로 도커 컨테이너 DB를 밀고 재실행하는 방식으로 개발을 진행하는게 나아보여서 관련 설정을 주석 처리해 두었는데 더 좋은 방법 있으면 피드백 부탁 드립니다!
- [x] ERD 네이밍 수정(erdcloud 반영완료)

- 역할 테이블 이름 role->project_role
- AI 회고 테이블 작성 팀원 id컬럼명 project_member_id ->writer_id
- 회의 참석자 테이블 참석자 id 컬럼명 project_member_id -attendee_id



## 📋 작업 결과
<img width="413" height="412" alt="image" src="https://github.com/user-attachments/assets/ae41ef24-2049-44e9-966d-dffd58d08baf" />

## 🔗 관련 이슈
- closed #4 

## 📝 기타
