### PR TITLE
[Refactor] 응답 구조 리팩토링 및 success 응답 message 필드 추가

### DIFF
--- a/src/main/java/com/connecteamed/server/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/connecteamed/server/global/apiPayload/ApiResponse.java
@@ -46,7 +46,7 @@ public class ApiResponse<T> {
     }
 
     //실패 응답 2 : data가 필요 없는 일반적인 경우 + custom message 사용
-    public static <T> ApiResponse<T> onSuccess(BaseSuccessCode code, String customMessage){
+    public static <T> ApiResponse<T> onFailure(BaseErrorCode code, String customMessage){
         return new ApiResponse<>("error",null, customMessage, code.getCode());
     }
 

--- a/src/main/java/com/connecteamed/server/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/connecteamed/server/global/apiPayload/ApiResponse.java
@@ -12,7 +12,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @JsonPropertyOrder({"status","data","message","code"})
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
     @JsonProperty("status")
@@ -27,18 +26,33 @@ public class ApiResponse<T> {
     @JsonProperty("code")
     private final String code;
 
-    //성공한 경우({status, data} 구조)
+    //성공 응답 (code는 NULL로 처리)
+
+    //성공 응답 1 : 에러 enum에 정의 된 메세지를 그대로 사용
     public static <T> ApiResponse<T> onSuccess(BaseSuccessCode code,T data){
-        return new ApiResponse<>("success",data, null, null);
+        return new ApiResponse<>("success",data, code.getMessage(), null);
     }
 
-    //실패한 경우 onFailure1 - 데이터가 필요 없는 일반적인 경우({status,message,code} 구조)
+    //성공 응답 2 : custom message 사용
+    public static <T> ApiResponse<T> onSuccess(BaseSuccessCode code,T data,String customMessage){
+        return new ApiResponse<>("success",data,customMessage,null);
+    }
+
+    //실패 응답 1,2  (data는 NULL로 처리)
+
+    //실패 응답 1 : data가 필요 없는 일반적인 경우 + 에러 enum에 정의 된 메세지를 그대로 사용
     public static <T> ApiResponse<T> onFailure(BaseErrorCode code){
         return new ApiResponse<>("error",null, code.getMessage(), code.getCode());
     }
 
+    //실패 응답 2 : data가 필요 없는 일반적인 경우 + custom message 사용
+    public static <T> ApiResponse<T> onSuccess(BaseSuccessCode code, String customMessage){
+        return new ApiResponse<>("error",null, customMessage, code.getCode());
+    }
 
-    //실패한 경우 onFailure2 - 만약 데이터까지 내려주어야 할 경우
+
+
+    //실패한 응답 3 : data까지 내려주어야 할 경우
     public static <T> ApiResponse<T> onFailure(BaseErrorCode code, T data){
         return new ApiResponse<>("error",data, code.getMessage(), code.getCode());
     }

--- a/src/main/java/com/connecteamed/server/global/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/connecteamed/server/global/apiPayload/exception/GeneralException.java
@@ -4,8 +4,25 @@ import com.connecteamed.server.global.apiPayload.code.BaseErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+
+/**
+ * [사용 예시]
+ * 1. 기본 메시지 사용 (Enum에 정의된 기본 문구)
+ * throw new GeneralException(GeneralErrorCode._BAD_REQUEST);
+ *
+ * 2. 상세 메시지 사용 (명세서에 따른 구체적 사유)
+ * throw new GeneralException(GeneralErrorCode._BAD_REQUEST, "이미 존재하는 닉네임입니다.");
+ */
 @Getter
 @AllArgsConstructor
 public class GeneralException extends RuntimeException {
     private final BaseErrorCode code;
+    private final String customMessage;
+
+
+    // 기본 메시지 사용 case를 위한 생성자 정의
+    public GeneralException(BaseErrorCode code) {
+        this.code = code;
+        this.customMessage = code.getMessage();
+    }
 }

--- a/src/main/java/com/connecteamed/server/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/connecteamed/server/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -13,14 +13,13 @@ public class GeneralExceptionAdvice {
 
     //애플리 케이션에서 발생하는 커스텀 예외 처리
     @ExceptionHandler(GeneralException.class)
-    public ResponseEntity<ApiResponse<Void>> handleException(GeneralException ex){
-
+    public ResponseEntity<ApiResponse<?>> handleException(GeneralException ex){
         return ResponseEntity.status(ex.getCode().getStatus())
-                .body(ApiResponse.onFailure(ex.getCode())
+                .body(ApiResponse.onFailure(ex.getCode(),ex.getCustomMessage())
                 );
     }
 
-    //사용자가 정의 하는 범위 외 발생 예외 처리- onFailure 1 구조를 따름
+    //사용자가 정의 하는 범위 외 발생 예외 처리- 실패응답 1 구조를 따름
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception ex){
         BaseErrorCode code = GeneralErrorCode.INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
## 📌 PR 요약
-  성공시 응답에 message 필드를 추가하고 커스텀 message를 처리할 수 있도록 ApiResponse와 GeneralException 파일 수정을 진행했습니다.
- 프론트엔드(TypeScript)에서 공통 응답 인터페이스를 통일해서 정의할 수 있도록 JSON 응답 구조를 표준화했습니다

## 🔧 변경 사항
- GeneralException.java: 기본 메시지 외에 상세 사유를 담을 수 있는 customMessage 필드 및 생성자 오버로딩 추가
- ApiResponse.java: 성공 응답에 message 필드 추가 및 @JsonInclude(NON_NULL) 제거를 통한 응답 구조 고정

## 📋 작업 상세 내용

- [x] 성공 응답 필드 확장: 기존 status, data 구조에서 message를 추가

- [x] 응답 구조 표준화(Nullable 제거): @JsonInclude(Include.NON_NULL) 어노테이션을 제거하여 성공/실패와 상관없이 isSuccess, code, message, result 필드가 항상 포함되도록 수정

프론트엔트 팀원분들이 TS를 쓰는 걸로 아는데 (NUllable)을 제거하면 성공했을 때랑 실패했을 때 응답 구조가 똑같아 지니까 APIResponse 인터페이스 정의를 편하게 할 수 있지 않을까..? 싶어서 일단 Nullable을 빼 놓았습니다

@JsonInclude(Include.NON_NULL)를 이용했을 때 Typescript APIResponse 정의 
<img width="500" height="286" alt="image" src="https://github.com/user-attachments/assets/d5328ae6-72ef-4f57-8a04-71b382e08ccd" />


@JsonInclude(Include.NON_NULL)를 이용하지 않았을 때 Typescript APIResponse 정의 
<img width="275" height="100" alt="image" src="https://github.com/user-attachments/assets/1626e0fc-14a3-401a-82eb-2279150b8cc7" />


- [x] GeneralException 생성 시점에 Enum의 기본 메시지 혹은 별도의 상세 커스텀 메시지를 선택적으로 주입할 수 있는 기능 구현

## 🔗 관련 이슈
- closed #12 
## 📝 기타
