### PR TITLE
Feat/5 task/document

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
   // Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
   // Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,11 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+  //AWS S3
+  implementation platform("software.amazon.awssdk:bom:2.25.60")
+  implementation "software.amazon.awssdk:s3"
+  implementation "software.amazon.awssdk:auth"
+
   // Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/connecteamed/server/ConnecteamedApplication.java
+++ b/src/main/java/com/connecteamed/server/ConnecteamedApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
+@EnableJpaAuditing(dateTimeProviderRef = "dateTimeProvider")
 public class ConnecteamedApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/connecteamed/server/domain/document/controller/DocumentController.java
+++ b/src/main/java/com/connecteamed/server/domain/document/controller/DocumentController.java
@@ -3,6 +3,9 @@ package com.connecteamed.server.domain.document.controller;
 import com.connecteamed.server.domain.document.dto.*;
 import com.connecteamed.server.domain.document.enums.DocumentFileType;
 import com.connecteamed.server.domain.document.service.DocumentService;
+import com.connecteamed.server.global.apiPayload.ApiResponse;
+import com.connecteamed.server.global.apiPayload.code.GeneralSuccessCode;
+
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,13 +24,13 @@ public class DocumentController {
     // 문서 목록 조회
     @GetMapping("/projects/{projectId}/documents")
     public ApiResponse<DocumentListRes> list(@PathVariable Long projectId) {
-        return ApiResponse.success(documentService.list(projectId));
+        return ApiResponse.onSuccess(GeneralSuccessCode._OK, documentService.list(projectId));
     }
 
     // 문서 상세 조회(모달)
     @GetMapping("/documents/{documentId}")
     public ApiResponse<DocumentDetailRes> detail(@PathVariable Long documentId) {
-        return ApiResponse.success(documentService.detail(documentId));
+        return ApiResponse.onSuccess(GeneralSuccessCode._OK, documentService.detail(documentId));
     }
 
     // 문서 다운로드(바이너리)
@@ -45,7 +48,7 @@ public class DocumentController {
     ) {
         Long projectMemberId = 1L; // TODO 인증에서 꺼내오기
         DocumentFileType fileType = DocumentFileType.valueOf(type);
-        return ApiResponse.success(documentService.uploadFile(projectId, projectMemberId, file, fileType));
+        return ApiResponse.onSuccess(GeneralSuccessCode._CREATED, documentService.uploadFile(projectId, projectMemberId, file, fileType));
     }
 
     // 문서 추가(텍스트 작성)
@@ -55,7 +58,7 @@ public class DocumentController {
             @RequestBody DocumentCreateTextReq req
     ) {
         Long projectMemberId = 1L; // TODO 인증에서 꺼내오기
-        return ApiResponse.success(documentService.createText(projectId, projectMemberId, req));
+        return ApiResponse.onSuccess(GeneralSuccessCode._CREATED, documentService.createText(projectId, projectMemberId, req));
     }
 
     // 문서 수정(텍스트만)
@@ -66,7 +69,7 @@ public class DocumentController {
     ) {
         Long projectMemberId = 1L; // TODO 인증에서 꺼내오기
         documentService.updateText(documentId, projectMemberId, req);
-        return ApiResponse.success(null);
+        return ApiResponse.onSuccess(GeneralSuccessCode._OK, null);
     }
 
     // 문서 삭제(소프트 삭제)
@@ -74,13 +77,7 @@ public class DocumentController {
     public ApiResponse<Void> delete(@PathVariable Long documentId) {
         Long projectMemberId = 1L; // TODO 인증에서 꺼내오기
         documentService.delete(documentId, projectMemberId);
-        return ApiResponse.success(null);
+        return ApiResponse.onSuccess(GeneralSuccessCode._OK, null);
     }
 
-    // 공통 응답 래퍼(이미 프로젝트에 있으면 이거는 빼고 기존거 쓰시면 됩니다)
-    public record ApiResponse<T>(String status, T data) {
-        public static <T> ApiResponse<T> success(T data) {
-            return new ApiResponse<>("success", data);
-        }
-    }
 }

--- a/src/main/java/com/connecteamed/server/domain/document/controller/DocumentController.java
+++ b/src/main/java/com/connecteamed/server/domain/document/controller/DocumentController.java
@@ -1,4 +1,86 @@
 package com.connecteamed.server.domain.document.controller;
 
+import com.connecteamed.server.domain.document.dto.*;
+import com.connecteamed.server.domain.document.enums.DocumentFileType;
+import com.connecteamed.server.domain.document.service.DocumentService;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api")
 public class DocumentController {
+
+    private final DocumentService documentService;
+
+    public DocumentController(DocumentService documentService) {
+        this.documentService = documentService;
+    }
+
+    // 문서 목록 조회
+    @GetMapping("/projects/{projectId}/documents")
+    public ApiResponse<DocumentListRes> list(@PathVariable Long projectId) {
+        return ApiResponse.success(documentService.list(projectId));
+    }
+
+    // 문서 상세 조회(모달)
+    @GetMapping("/documents/{documentId}")
+    public ApiResponse<DocumentDetailRes> detail(@PathVariable Long documentId) {
+        return ApiResponse.success(documentService.detail(documentId));
+    }
+
+    // 문서 다운로드(바이너리)
+    @GetMapping("/documents/{documentId}/download")
+    public ResponseEntity<Resource> download(@PathVariable Long documentId) {
+        return documentService.download(documentId);
+    }
+
+    // 문서 추가(파일 업로드)
+    @PostMapping(value = "/projects/{projectId}/documents/upload", consumes = "multipart/form-data")
+    public ApiResponse<DocumentUploadRes> upload(
+            @PathVariable Long projectId,
+            @RequestPart("file") MultipartFile file,
+            @RequestPart("type") String type
+    ) {
+        Long projectMemberId = 1L; // TODO 인증에서 꺼내오기
+        DocumentFileType fileType = DocumentFileType.valueOf(type);
+        return ApiResponse.success(documentService.uploadFile(projectId, projectMemberId, file, fileType));
+    }
+
+    // 문서 추가(텍스트 작성)
+    @PostMapping("/projects/{projectId}/documents/text")
+    public ApiResponse<DocumentCreateRes> createText(
+            @PathVariable Long projectId,
+            @RequestBody DocumentCreateTextReq req
+    ) {
+        Long projectMemberId = 1L; // TODO 인증에서 꺼내오기
+        return ApiResponse.success(documentService.createText(projectId, projectMemberId, req));
+    }
+
+    // 문서 수정(텍스트만)
+    @PatchMapping("/documents/{documentId}")
+    public ApiResponse<Void> updateText(
+            @PathVariable Long documentId,
+            @RequestBody DocumentUpdateTextReq req
+    ) {
+        Long projectMemberId = 1L; // TODO 인증에서 꺼내오기
+        documentService.updateText(documentId, projectMemberId, req);
+        return ApiResponse.success(null);
+    }
+
+    // 문서 삭제(소프트 삭제)
+    @DeleteMapping("/documents/{documentId}")
+    public ApiResponse<Void> delete(@PathVariable Long documentId) {
+        Long projectMemberId = 1L; // TODO 인증에서 꺼내오기
+        documentService.delete(documentId, projectMemberId);
+        return ApiResponse.success(null);
+    }
+
+    // 공통 응답 래퍼(이미 프로젝트에 있으면 이거는 빼고 기존거 쓰시면 됩니다)
+    public record ApiResponse<T>(String status, T data) {
+        public static <T> ApiResponse<T> success(T data) {
+            return new ApiResponse<>("success", data);
+        }
+    }
 }

--- a/src/main/java/com/connecteamed/server/domain/document/controller/DocumentController.java
+++ b/src/main/java/com/connecteamed/server/domain/document/controller/DocumentController.java
@@ -1,15 +1,30 @@
 package com.connecteamed.server.domain.document.controller;
 
-import com.connecteamed.server.domain.document.dto.*;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.connecteamed.server.domain.document.dto.DocumentCreateRes;
+import com.connecteamed.server.domain.document.dto.DocumentCreateTextReq;
+import com.connecteamed.server.domain.document.dto.DocumentDetailRes;
+import com.connecteamed.server.domain.document.dto.DocumentListRes;
+import com.connecteamed.server.domain.document.dto.DocumentUpdateTextReq;
+import com.connecteamed.server.domain.document.dto.DocumentUploadRes;
 import com.connecteamed.server.domain.document.enums.DocumentFileType;
 import com.connecteamed.server.domain.document.service.DocumentService;
 import com.connecteamed.server.global.apiPayload.ApiResponse;
 import com.connecteamed.server.global.apiPayload.code.GeneralSuccessCode;
 
-import org.springframework.core.io.Resource;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api")
@@ -55,7 +70,7 @@ public class DocumentController {
     @PostMapping("/projects/{projectId}/documents/text")
     public ApiResponse<DocumentCreateRes> createText(
             @PathVariable Long projectId,
-            @RequestBody DocumentCreateTextReq req
+            @Valid @RequestBody DocumentCreateTextReq req
     ) {
         Long projectMemberId = 1L; // TODO 인증에서 꺼내오기
         return ApiResponse.onSuccess(GeneralSuccessCode._CREATED, documentService.createText(projectId, projectMemberId, req));

--- a/src/main/java/com/connecteamed/server/domain/document/dto/DocumentCreateRes.java
+++ b/src/main/java/com/connecteamed/server/domain/document/dto/DocumentCreateRes.java
@@ -1,0 +1,6 @@
+package com.connecteamed.server.domain.document.dto;
+
+public record DocumentCreateRes(
+        Long documentId,
+        String createdAt
+) {}

--- a/src/main/java/com/connecteamed/server/domain/document/dto/DocumentCreateTextReq.java
+++ b/src/main/java/com/connecteamed/server/domain/document/dto/DocumentCreateTextReq.java
@@ -1,6 +1,11 @@
 package com.connecteamed.server.domain.document.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record DocumentCreateTextReq(
+        @NotBlank(message = "제목은 필수입니다.")
         String title,
+
+        @NotBlank(message = "내용은 필수입니다.")
         String content
 ) {}

--- a/src/main/java/com/connecteamed/server/domain/document/dto/DocumentCreateTextReq.java
+++ b/src/main/java/com/connecteamed/server/domain/document/dto/DocumentCreateTextReq.java
@@ -1,0 +1,6 @@
+package com.connecteamed.server.domain.document.dto;
+
+public record DocumentCreateTextReq(
+        String title,
+        String content
+) {}

--- a/src/main/java/com/connecteamed/server/domain/document/dto/DocumentDetailRes.java
+++ b/src/main/java/com/connecteamed/server/domain/document/dto/DocumentDetailRes.java
@@ -1,0 +1,11 @@
+package com.connecteamed.server.domain.document.dto;
+
+public record DocumentDetailRes(
+        Long documentId,
+        String title,
+        String type,
+        String content,      // TEXT면 채움
+        String downloadUrl,  // 파일이면 채움
+        String createdAt,
+        String updatedAt
+) {}

--- a/src/main/java/com/connecteamed/server/domain/document/dto/DocumentListRes.java
+++ b/src/main/java/com/connecteamed/server/domain/document/dto/DocumentListRes.java
@@ -1,0 +1,17 @@
+package com.connecteamed.server.domain.document.dto;
+
+import java.util.List;
+
+public record DocumentListRes(
+        List<Item> documents
+) {
+    public record Item(
+            Long documentId,
+            String title,
+            String type,
+            String uploaderName,
+            String uploadDate,
+            String downloadUrl,
+            boolean canEdit
+    ) {}
+}

--- a/src/main/java/com/connecteamed/server/domain/document/dto/DocumentUpdateTextReq.java
+++ b/src/main/java/com/connecteamed/server/domain/document/dto/DocumentUpdateTextReq.java
@@ -1,0 +1,6 @@
+package com.connecteamed.server.domain.document.dto;
+
+public record DocumentUpdateTextReq(
+        String title,
+        String content
+) {}

--- a/src/main/java/com/connecteamed/server/domain/document/dto/DocumentUploadRes.java
+++ b/src/main/java/com/connecteamed/server/domain/document/dto/DocumentUploadRes.java
@@ -1,0 +1,7 @@
+package com.connecteamed.server.domain.document.dto;
+
+public record DocumentUploadRes(
+        Long documentId,
+        String fileName,
+        String createdAt
+) {}

--- a/src/main/java/com/connecteamed/server/domain/document/entity/Document.java
+++ b/src/main/java/com/connecteamed/server/domain/document/entity/Document.java
@@ -7,7 +7,7 @@ import com.connecteamed.server.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.OffsetDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Entity
@@ -47,7 +47,7 @@ public class Document extends BaseEntity {
     private String content;
 
     @Column(name = "deleted_at")
-    private OffsetDateTime deletedAt;
+    private Instant deletedAt;
 
     @PrePersist
     public void prePersist() {
@@ -99,6 +99,6 @@ public class Document extends BaseEntity {
     }
 
     public void softDelete() {
-        this.deletedAt = OffsetDateTime.now();
+        this.deletedAt = Instant.now();
     }
 }

--- a/src/main/java/com/connecteamed/server/domain/document/entity/Document.java
+++ b/src/main/java/com/connecteamed/server/domain/document/entity/Document.java
@@ -87,8 +87,15 @@ public class Document extends BaseEntity {
         if (this.fileType != DocumentFileType.TEXT) {
             throw new IllegalArgumentException("TEXT 문서만 수정할 수 있습니다.");
         }
-        this.title = title;
-        this.content = content;
+        if (title != null) {
+            if (title.isBlank()) {
+                throw new IllegalArgumentException("제목은 공백일 수 없습니다.");
+            }
+            this.title = title;
+        }
+        if (content != null) {
+            this.content = content;
+        }
     }
 
     public void softDelete() {

--- a/src/main/java/com/connecteamed/server/domain/document/entity/Document.java
+++ b/src/main/java/com/connecteamed/server/domain/document/entity/Document.java
@@ -1,6 +1,6 @@
 package com.connecteamed.server.domain.document.entity;
 
-import com.connecteamed.server.domain.document.enums.FileType;
+import com.connecteamed.server.domain.document.enums.DocumentFileType;
 import com.connecteamed.server.domain.project.entity.Project;
 import com.connecteamed.server.domain.project.entity.ProjectMember;
 import com.connecteamed.server.global.entity.BaseEntity;
@@ -10,50 +10,88 @@ import lombok.*;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
-
 @Entity
 @Builder
-@NoArgsConstructor(access= AccessLevel.PROTECTED)
-@AllArgsConstructor(access= AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-@Table(name= "document")
+@Table(name = "document")
 public class Document extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name="public_id",nullable = false,unique = true,columnDefinition = "UUID")
+    @Column(name = "public_id", nullable = false, unique = true, columnDefinition = "UUID")
     private UUID publicId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="project_id",nullable = false)
+    @JoinColumn(name = "project_id", nullable = false)
     private Project project;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="project_member_id",nullable = false)
+    @JoinColumn(name = "project_member_id", nullable = false)
     private ProjectMember projectMember;
 
-    @Column(name="title",nullable = false)
+    @Column(name = "title", nullable = false)
     private String title;
 
     @Enumerated(EnumType.STRING)
-    @Column(name="file_type",nullable = false)
-    private FileType fileType;
+    @Column(name = "file_type", nullable = false)
+    private DocumentFileType fileType;
 
     @Column(name = "file_url", columnDefinition = "TEXT")
     private String fileUrl;
 
-    @Column(name="content", columnDefinition = "TEXT")
+    @Column(name = "content", columnDefinition = "TEXT")
     private String content;
 
-    @Column(name="deleted_at")
+    @Column(name = "deleted_at")
     private OffsetDateTime deletedAt;
 
     @PrePersist
-    public void prePersist(){
-        if(this.publicId == null){
+    public void prePersist() {
+        if (this.publicId == null) {
             this.publicId = UUID.randomUUID();
         }
     }
 
+    public static Document createText(Project project, ProjectMember projectMember, String title, String content) {
+        return Document.builder()
+                .project(project)
+                .projectMember(projectMember)
+                .title(title)
+                .fileType(DocumentFileType.TEXT)
+                .fileUrl(null)
+                .content(content)
+                .deletedAt(null)
+                .build();
+    }
+
+    public static Document createFile(Project project, ProjectMember projectMember, String title, DocumentFileType type, String fileUrl) {
+        if (type == DocumentFileType.TEXT) {
+            throw new IllegalArgumentException("TEXT 타입은 createFile로 생성할 수 없습니다.");
+        }
+        return Document.builder()
+                .project(project)
+                .projectMember(projectMember)
+                .title(title)
+                .fileType(type)
+                .fileUrl(fileUrl)
+                .content(null)
+                .deletedAt(null)
+                .build();
+    }
+
+    public void updateText(String title, String content) {
+        if (this.fileType != DocumentFileType.TEXT) {
+            throw new IllegalArgumentException("TEXT 문서만 수정할 수 있습니다.");
+        }
+        this.title = title;
+        this.content = content;
+    }
+
+    public void softDelete() {
+        this.deletedAt = OffsetDateTime.now();
+    }
 }

--- a/src/main/java/com/connecteamed/server/domain/document/enums/DocumentFileType.java
+++ b/src/main/java/com/connecteamed/server/domain/document/enums/DocumentFileType.java
@@ -1,0 +1,9 @@
+package com.connecteamed.server.domain.document.enums;
+
+public enum DocumentFileType {
+    PDF, DOCX, IMAGE, TEXT;
+
+    public boolean isFile() {
+        return this != TEXT;
+    }
+}

--- a/src/main/java/com/connecteamed/server/domain/document/enums/FileType.java
+++ b/src/main/java/com/connecteamed/server/domain/document/enums/FileType.java
@@ -1,8 +1,0 @@
-package com.connecteamed.server.domain.document.enums;
-
-public enum FileType {
-    PDF,
-    DOCX,
-    IMAGE,
-    TEXT
-}

--- a/src/main/java/com/connecteamed/server/domain/document/repository/DocumentRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/document/repository/DocumentRepository.java
@@ -1,4 +1,14 @@
 package com.connecteamed.server.domain.document.repository;
 
-public class DocumentRepository {
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.connecteamed.server.domain.document.entity.Document;
+
+public interface DocumentRepository extends JpaRepository<Document, Long> {
+    Optional<Document> findByIdAndDeletedAtIsNull(Long id);
+
+    List<Document> findAllByProjectIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long projectId);
 }

--- a/src/main/java/com/connecteamed/server/domain/document/service/DocumentService.java
+++ b/src/main/java/com/connecteamed/server/domain/document/service/DocumentService.java
@@ -1,4 +1,18 @@
 package com.connecteamed.server.domain.document.service;
 
-public class DocumentService {
+import com.connecteamed.server.domain.document.dto.*;
+import com.connecteamed.server.domain.document.enums.DocumentFileType;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface DocumentService {
+    DocumentListRes list(Long projectId);
+    DocumentDetailRes detail(Long documentId);
+    ResponseEntity<Resource> download(Long documentId);
+
+    DocumentCreateRes createText(Long projectId, Long projectMemberId, DocumentCreateTextReq req);
+    DocumentUploadRes uploadFile(Long projectId, Long projectMemberId, MultipartFile file, DocumentFileType type);
+    void updateText(Long documentId, Long projectMemberId, DocumentUpdateTextReq req);
+    void delete(Long documentId, Long projectMemberId);
 }

--- a/src/main/java/com/connecteamed/server/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/document/service/DocumentServiceImpl.java
@@ -28,6 +28,8 @@ import com.connecteamed.server.domain.project.entity.Project;
 import com.connecteamed.server.domain.project.entity.ProjectMember;
 import com.connecteamed.server.domain.project.repository.ProjectMemberRepository;
 import com.connecteamed.server.domain.project.repository.ProjectRepository;
+import com.connecteamed.server.global.apiPayload.code.GeneralErrorCode;
+import com.connecteamed.server.global.apiPayload.exception.GeneralException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -71,7 +73,7 @@ public class DocumentServiceImpl implements DocumentService {
     @Transactional(readOnly = true)
     public DocumentDetailRes detail(Long documentId) {
         Document d = documentRepository.findByIdAndDeletedAtIsNull(documentId)
-                .orElseThrow(() -> new IllegalArgumentException("문서를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND, "문서를 찾을 수 없습니다."));
 
         return new DocumentDetailRes(
                 d.getId(),

--- a/src/main/java/com/connecteamed/server/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/document/service/DocumentServiceImpl.java
@@ -119,7 +119,7 @@ public class DocumentServiceImpl implements DocumentService {
                     .body(resource);
 
         } catch (Exception e) {
-            throw new IllegalArgumentException("파일 다운로드에 실패했습니다.");
+            throw new IllegalArgumentException("파일 다운로드에 실패했습니다.", e);
         }
     }
 

--- a/src/main/java/com/connecteamed/server/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/document/service/DocumentServiceImpl.java
@@ -1,0 +1,170 @@
+package com.connecteamed.server.domain.document.service;
+
+// imports 추가
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.connecteamed.server.domain.document.dto.DocumentCreateRes;
+import com.connecteamed.server.domain.document.dto.DocumentCreateTextReq;
+import com.connecteamed.server.domain.document.dto.DocumentDetailRes;
+import com.connecteamed.server.domain.document.dto.DocumentListRes;
+import com.connecteamed.server.domain.document.dto.DocumentUpdateTextReq;
+import com.connecteamed.server.domain.document.dto.DocumentUploadRes;
+import com.connecteamed.server.domain.document.entity.Document;
+import com.connecteamed.server.domain.document.enums.DocumentFileType;
+import com.connecteamed.server.domain.document.repository.DocumentRepository;
+import com.connecteamed.server.domain.project.entity.Project;
+import com.connecteamed.server.domain.project.entity.ProjectMember;
+import com.connecteamed.server.domain.project.repository.ProjectMemberRepository;
+import com.connecteamed.server.domain.project.repository.ProjectRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DocumentServiceImpl implements DocumentService {
+
+    private final DocumentRepository documentRepository;
+    private final ProjectRepository projectRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+    private final S3StorageService s3StorageService;
+
+    @Override
+    @Transactional(readOnly = true)
+    public DocumentListRes list(Long projectId) {
+        List<Document> docs =
+                documentRepository.findAllByProjectIdAndDeletedAtIsNullOrderByCreatedAtDesc(projectId);
+
+        DateTimeFormatter df = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+        return new DocumentListRes(
+                docs.stream()
+                        .map(d -> new DocumentListRes.Item(
+                                d.getId(),
+                                d.getTitle(),
+                                d.getFileType().name(),
+                                "TODO_업로더명", // 필요하면 projectMember에서 이름 꺼내서 세팅
+                                d.getCreatedAt().toLocalDate().format(df),
+                                (d.getFileType() != DocumentFileType.TEXT)
+                                        ? "/api/documents/" + d.getId() + "/download"
+                                        : null,
+                                d.getFileType() == DocumentFileType.TEXT
+                        ))
+                        .toList()
+        );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public DocumentDetailRes detail(Long documentId) {
+        Document d = documentRepository.findByIdAndDeletedAtIsNull(documentId)
+                .orElseThrow(() -> new IllegalArgumentException("문서를 찾을 수 없습니다."));
+
+        return new DocumentDetailRes(
+                d.getId(),
+                d.getTitle(),
+                d.getFileType().name(),
+                (d.getFileType() == DocumentFileType.TEXT) ? d.getContent() : null,
+                (d.getFileType() != DocumentFileType.TEXT) ? "/api/documents/" + d.getId() + "/download" : null,
+                d.getCreatedAt().toString(),
+                d.getUpdatedAt().toString()
+        );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ResponseEntity<Resource> download(Long documentId) {
+        Document d = documentRepository.findByIdAndDeletedAtIsNull(documentId)
+                .orElseThrow(() -> new IllegalArgumentException("문서를 찾을 수 없습니다."));
+
+        if (d.getFileType() == DocumentFileType.TEXT) {
+            throw new IllegalArgumentException("TEXT 문서는 다운로드 대상이 아닙니다.");
+        }
+        if (d.getFileUrl() == null || d.getFileUrl().isBlank()) {
+            throw new IllegalArgumentException("파일 URL이 없습니다.");
+        }
+
+        try {
+            Resource resource = new UrlResource(URI.create(d.getFileUrl()));
+            String encoded = URLEncoder.encode(d.getTitle(), StandardCharsets.UTF_8).replace("+", "%20");
+
+            return ResponseEntity.ok()
+                    .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + encoded + "\"")
+                    .body(resource);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("파일 다운로드에 실패했습니다.");
+        }
+    }
+
+    @Override
+    @Transactional
+    public DocumentCreateRes createText(Long projectId, Long projectMemberId, DocumentCreateTextReq req) {
+        Project projectRef = projectRepository.getReferenceById(projectId);
+        ProjectMember projectMemberRef = projectMemberRepository.getReferenceById(projectMemberId);
+
+        Document d = Document.createText(projectRef, projectMemberRef, req.title(), req.content());
+        documentRepository.save(d);
+
+        return new DocumentCreateRes(d.getId(), d.getCreatedAt().toString());
+    }
+
+    @Override
+    @Transactional
+    public DocumentUploadRes uploadFile(Long projectId, Long projectMemberId, MultipartFile file, DocumentFileType type) {
+        if (type == DocumentFileType.TEXT) {
+            throw new IllegalArgumentException("TEXT는 파일 업로드 타입이 아닙니다.");
+        }
+
+        Project projectRef = projectRepository.getReferenceById(projectId);
+        ProjectMember projectMemberRef = projectMemberRepository.getReferenceById(projectMemberId);
+
+        String fileUrl = s3StorageService.upload(file, "project-" + projectId);
+
+        String title = (file.getOriginalFilename() == null || file.getOriginalFilename().isBlank())
+                ? "file"
+                : file.getOriginalFilename();
+
+        Document d = Document.createFile(projectRef, projectMemberRef, title, type, fileUrl);
+        documentRepository.save(d);
+
+        return new DocumentUploadRes(d.getId(), title, d.getCreatedAt().toString());
+    }
+
+    @Override
+    @Transactional
+    public void updateText(Long documentId, Long projectMemberId, DocumentUpdateTextReq req) {
+        Document d = documentRepository.findByIdAndDeletedAtIsNull(documentId)
+                .orElseThrow(() -> new IllegalArgumentException("문서를 찾을 수 없습니다."));
+
+        if (d.getFileType() != DocumentFileType.TEXT) {
+            throw new IllegalArgumentException("텍스트 문서만 수정할 수 있습니다.");
+        }
+
+        d.updateText(req.title(), req.content());
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long documentId, Long projectMemberId) {
+        Document d = documentRepository.findByIdAndDeletedAtIsNull(documentId)
+                .orElseThrow(() -> new IllegalArgumentException("문서를 찾을 수 없습니다."));
+
+        // 파일 문서면 필요 시 S3 삭제 정책 추가 가능
+        // if (d.getFileType() != DocumentFileType.TEXT) { ... }
+
+        d.softDelete();
+    }
+}

--- a/src/main/java/com/connecteamed/server/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/document/service/DocumentServiceImpl.java
@@ -90,13 +90,13 @@ public class DocumentServiceImpl implements DocumentService {
     @Transactional(readOnly = true)
     public ResponseEntity<Resource> download(Long documentId) {
         Document d = documentRepository.findByIdAndDeletedAtIsNull(documentId)
-                .orElseThrow(() -> new IllegalArgumentException("문서를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND, "문서를 찾을 수 없습니다."));
 
         if (d.getFileType() == DocumentFileType.TEXT) {
-            throw new IllegalArgumentException("TEXT 문서는 다운로드 대상이 아닙니다.");
+            throw new GeneralException(GeneralErrorCode.FORBIDDEN, "TEXT 문서는 다운로드 대상이 아닙니다.");
         }
         if (d.getFileUrl() == null || d.getFileUrl().isBlank()) {
-            throw new IllegalArgumentException("파일 key가 없습니다.");
+            throw new GeneralException(GeneralErrorCode.NOT_FOUND, "파일 key가 없습니다.");
         }
 
         String key = d.getFileUrl();
@@ -119,7 +119,7 @@ public class DocumentServiceImpl implements DocumentService {
                     .body(resource);
 
         } catch (Exception e) {
-            throw new IllegalArgumentException("파일 다운로드에 실패했습니다.", e);
+            throw new GeneralException(GeneralErrorCode.NOT_FOUND, "파일 다운로드에 실패했습니다.");
         }
     }
 
@@ -139,7 +139,7 @@ public class DocumentServiceImpl implements DocumentService {
     @Transactional
     public DocumentUploadRes uploadFile(Long projectId, Long projectMemberId, MultipartFile file, DocumentFileType type) {
         if (type == DocumentFileType.TEXT) {
-            throw new IllegalArgumentException("TEXT는 파일 업로드 타입이 아닙니다.");
+            throw new GeneralException(GeneralErrorCode.BAD_REQUEST, "TEXT는 파일 업로드 타입이 아닙니다.");
         }
 
         Project projectRef = projectRepository.getReferenceById(projectId);
@@ -161,10 +161,10 @@ public class DocumentServiceImpl implements DocumentService {
     @Transactional
     public void updateText(Long documentId, Long projectMemberId, DocumentUpdateTextReq req) {
         Document d = documentRepository.findByIdAndDeletedAtIsNull(documentId)
-                .orElseThrow(() -> new IllegalArgumentException("문서를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND, "문서를 찾을 수 없습니다."));
 
         if (d.getFileType() != DocumentFileType.TEXT) {
-            throw new IllegalArgumentException("텍스트 문서만 수정할 수 있습니다.");
+            throw new GeneralException(GeneralErrorCode.BAD_REQUEST, "텍스트 문서만 수정할 수 있습니다.");
         }
 
         d.updateText(req.title(), req.content());
@@ -174,7 +174,7 @@ public class DocumentServiceImpl implements DocumentService {
     @Transactional
     public void delete(Long documentId, Long projectMemberId) {
         Document d = documentRepository.findByIdAndDeletedAtIsNull(documentId)
-                .orElseThrow(() -> new IllegalArgumentException("문서를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND, "문서를 찾을 수 없습니다."));
 
         // 파일 문서면 필요 시 S3 삭제 정책 추가 가능
         // if (d.getFileType() != DocumentFileType.TEXT) { ... }

--- a/src/main/java/com/connecteamed/server/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/document/service/DocumentServiceImpl.java
@@ -5,6 +5,8 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
@@ -50,7 +52,8 @@ public class DocumentServiceImpl implements DocumentService {
         List<Document> docs =
                 documentRepository.findAllByProjectIdAndDeletedAtIsNullOrderByCreatedAtDesc(projectId);
 
-        DateTimeFormatter df = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        DateTimeFormatter df = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+                .withZone(ZoneId.of("Asia/Seoul"));
 
         return new DocumentListRes(
                 docs.stream()
@@ -59,7 +62,7 @@ public class DocumentServiceImpl implements DocumentService {
                                 d.getTitle(),
                                 d.getFileType().name(),
                                 "TODO_업로더명", // 필요하면 projectMember에서 이름 꺼내서 세팅
-                                d.getCreatedAt().toLocalDate().format(df),
+                                df.format(d.getCreatedAt()),
                                 (d.getFileType() != DocumentFileType.TEXT)
                                         ? "/api/documents/" + d.getId() + "/download"
                                         : null,

--- a/src/main/java/com/connecteamed/server/domain/document/service/S3StorageService.java
+++ b/src/main/java/com/connecteamed/server/domain/document/service/S3StorageService.java
@@ -1,0 +1,10 @@
+package com.connecteamed.server.domain.document.service;
+
+import org.springframework.web.multipart.MultipartFile;
+import java.io.InputStream;
+
+public interface S3StorageService {
+    String upload(MultipartFile file, String keyPrefix);
+    InputStream download(String key);
+    String guessDownloadFileName(String key);
+}

--- a/src/main/java/com/connecteamed/server/domain/document/service/S3StorageServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/document/service/S3StorageServiceImpl.java
@@ -3,6 +3,8 @@ package com.connecteamed.server.domain.document.service;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+
+import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -12,6 +14,7 @@ import java.io.InputStream;
 import java.nio.file.Paths;
 import java.util.UUID;
 
+@Slf4j
 @Service
 public class S3StorageServiceImpl implements S3StorageService {
 
@@ -45,6 +48,8 @@ public class S3StorageServiceImpl implements S3StorageService {
             s3Client.putObject(req, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
             return key; // DB에는 key 저장 권장
         } catch (Exception e) {
+            log.error("S3 upload failed. bucket={}, prefix={}, keyPrefix={}, filename={}, size={}",
+                bucket, prefix, keyPrefix, file.getOriginalFilename(), file.getSize(), e);
             throw new RuntimeException("S3 업로드 실패", e);
         }
     }

--- a/src/main/java/com/connecteamed/server/domain/document/service/S3StorageServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/document/service/S3StorageServiceImpl.java
@@ -1,0 +1,65 @@
+package com.connecteamed.server.domain.document.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.InputStream;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Service
+public class S3StorageServiceImpl implements S3StorageService {
+
+    private final S3Client s3Client;
+    private final String bucket;
+    private final String prefix;
+
+    public S3StorageServiceImpl(
+            S3Client s3Client,
+            @Value("${app.s3.bucket}") String bucket,
+            @Value("${app.s3.prefix:documents}") String prefix
+    ) {
+        this.s3Client = s3Client;
+        this.bucket = bucket;
+        this.prefix = prefix;
+    }
+
+    @Override
+    public String upload(MultipartFile file, String keyPrefix) {
+        try {
+            String original = file.getOriginalFilename() == null ? "file" : file.getOriginalFilename();
+            String safeName = original.replaceAll("[\\\\/]", "_");
+            String key = "%s/%s/%s_%s".formatted(prefix, keyPrefix, UUID.randomUUID(), safeName);
+
+            PutObjectRequest req = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(req, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+            return key; // DB에는 key 저장 권장
+        } catch (Exception e) {
+            throw new RuntimeException("S3 업로드 실패", e);
+        }
+    }
+
+    @Override
+    public InputStream download(String key) {
+        GetObjectRequest req = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+        return s3Client.getObject(req);
+    }
+
+    @Override
+    public String guessDownloadFileName(String key) {
+        return Paths.get(key).getFileName().toString();
+    }
+}

--- a/src/main/java/com/connecteamed/server/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/project/repository/ProjectMemberRepository.java
@@ -1,0 +1,9 @@
+package com.connecteamed.server.domain.project.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.connecteamed.server.domain.project.entity.ProjectMember;
+
+public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
+    Optional<ProjectMember> findByIdAndProjectId(Long id, Long projectId);
+}

--- a/src/main/java/com/connecteamed/server/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/project/repository/ProjectRepository.java
@@ -1,4 +1,7 @@
 package com.connecteamed.server.domain.project.repository;
 
-public class ProjectRepository {
+import com.connecteamed.server.domain.project.entity.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
 }

--- a/src/main/java/com/connecteamed/server/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/connecteamed/server/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -1,15 +1,47 @@
 package com.connecteamed.server.global.apiPayload.handler;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
 import com.connecteamed.server.global.apiPayload.ApiResponse;
 import com.connecteamed.server.global.apiPayload.code.BaseErrorCode;
 import com.connecteamed.server.global.apiPayload.code.GeneralErrorCode;
 import com.connecteamed.server.global.apiPayload.exception.GeneralException;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import jakarta.validation.ConstraintViolationException;
 
 @RestControllerAdvice
 public class GeneralExceptionAdvice {
+    
+    // 1) @RequestParam / @PathVariable 검증 실패
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleConstraintViolation(ConstraintViolationException ex) {
+        BaseErrorCode code = GeneralErrorCode.BAD_REQUEST;
+
+        // 메시지 예: "detail.documentId: must be greater than or equal to 1"
+        String message = (ex.getConstraintViolations().isEmpty())
+                ? code.getMessage()
+                : ex.getConstraintViolations().iterator().next().getMessage();
+
+        return ResponseEntity.status(code.getStatus())
+                .body(ApiResponse.onFailure(code, message));
+    }
+
+    // 2) JSON 파싱 자체가 실패 (문법 오류/타입 불일치 등)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNotReadable(HttpMessageNotReadableException ex) {
+        BaseErrorCode code = GeneralErrorCode.BAD_REQUEST;
+
+        // 너무 내부정보를 노출하지 않으려면 고정 메시지 추천
+        String message = "요청 본문(JSON) 형식이 올바르지 않습니다.";
+
+        return ResponseEntity.status(code.getStatus())
+                .body(ApiResponse.onFailure(code, message));
+    }
 
     //애플리 케이션에서 발생하는 커스텀 예외 처리
     @ExceptionHandler(GeneralException.class)
@@ -17,6 +49,22 @@ public class GeneralExceptionAdvice {
         return ResponseEntity.status(ex.getCode().getStatus())
                 .body(ApiResponse.onFailure(ex.getCode(),ex.getCustomMessage())
                 );
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException ex) {
+        BaseErrorCode code = GeneralErrorCode.BAD_REQUEST;
+
+        FieldError fieldError = ex.getBindingResult().getFieldErrors().isEmpty()
+                ? null
+                : ex.getBindingResult().getFieldErrors().get(0);
+
+        String message = (fieldError != null && fieldError.getDefaultMessage() != null)
+                ? fieldError.getDefaultMessage()
+                : code.getMessage();
+
+        return ResponseEntity.status(code.getStatus())
+                .body(ApiResponse.onFailure(code, message));
     }
 
     //사용자가 정의 하는 범위 외 발생 예외 처리- 실패응답 1 구조를 따름

--- a/src/main/java/com/connecteamed/server/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/connecteamed/server/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -67,6 +67,13 @@ public class GeneralExceptionAdvice {
                 .body(ApiResponse.onFailure(code, message));
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException ex) {
+        BaseErrorCode code = GeneralErrorCode.BAD_REQUEST;
+        return ResponseEntity.status(code.getStatus())
+                .body(ApiResponse.onFailure(code, ex.getMessage()));
+    }
+
     //사용자가 정의 하는 범위 외 발생 예외 처리- 실패응답 1 구조를 따름
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception ex){

--- a/src/main/java/com/connecteamed/server/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/connecteamed/server/global/config/JpaAuditingConfig.java
@@ -1,0 +1,16 @@
+package com.connecteamed.server.global.config;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+
+@Configuration
+public class JpaAuditingConfig {
+
+    @Bean
+    public DateTimeProvider dateTimeProvider() {
+        return () -> Optional.of(OffsetDateTime.now());
+    }
+}

--- a/src/main/java/com/connecteamed/server/global/config/S3Config.java
+++ b/src/main/java/com/connecteamed/server/global/config/S3Config.java
@@ -3,6 +3,8 @@ package com.connecteamed.server.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -10,9 +12,16 @@ import software.amazon.awssdk.services.s3.S3Client;
 public class S3Config {
 
     @Bean
-    S3Client s3Client(@Value("${app.s3.region}") String region) {
+    public S3Client s3Client(
+            @Value("${app.s3.region}") String region,
+            @Value("${app.s3.access-key}") String accessKey,
+            @Value("${app.s3.secret-key}") String secretKey
+    ) {
         return S3Client.builder()
                 .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey))
+                )
                 .build();
     }
 }

--- a/src/main/java/com/connecteamed/server/global/config/S3Config.java
+++ b/src/main/java/com/connecteamed/server/global/config/S3Config.java
@@ -1,0 +1,18 @@
+package com.connecteamed.server.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Bean
+    S3Client s3Client(@Value("${app.s3.region}") String region) {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
@@ -1,4 +1,46 @@
 package com.connecteamed.server.global.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .cors(Customizer.withDefaults())
+
+            .authorizeHttpRequests(auth -> auth
+                // 정적 페이지 (resources/static)
+                .requestMatchers(
+                    "/", "/index.html",
+                    "/document.html",
+                    "/css/**", "/js/**", "/images/**",
+                    "/favicon.ico",
+                    "/error"
+                ).permitAll()
+
+                // 문서 API 전부 허용(테스트용)
+                .requestMatchers("/api/**").permitAll()
+
+                // 혹은 문서만 열고 싶으면 예시처럼 세분화도 가능
+                // .requestMatchers("/api/projects/*/documents/**", "/api/documents/**").permitAll()
+
+                // 나머지는 막기
+                .anyRequest().authenticated()
+            )
+
+            // 폼 로그인 페이지 자체도 잠깐 끄기(리다이렉트 방지)
+            .formLogin(form -> form.disable())
+            .httpBasic(basic -> basic.disable());
+
+        return http.build();
+    }
 }

--- a/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
@@ -2,7 +2,6 @@ package com.connecteamed.server.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -14,32 +13,17 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(csrf -> csrf.disable())
-            .cors(Customizer.withDefaults())
-
-            .authorizeHttpRequests(auth -> auth
-                // 정적 페이지 (resources/static)
-                .requestMatchers(
-                    "/", "/index.html",
-                    "/document.html",
-                    "/css/**", "/js/**", "/images/**",
-                    "/favicon.ico",
-                    "/error"
-                ).permitAll()
-
-                // 문서 API 전부 허용(테스트용)
-                .requestMatchers("/api/**").permitAll()
-
-                // 혹은 문서만 열고 싶으면 예시처럼 세분화도 가능
-                // .requestMatchers("/api/projects/*/documents/**", "/api/documents/**").permitAll()
-
-                // 나머지는 막기
-                .anyRequest().authenticated()
-            )
-
-            // 폼 로그인 페이지 자체도 잠깐 끄기(리다이렉트 방지)
-            .formLogin(form -> form.disable())
-            .httpBasic(basic -> basic.disable());
+                .csrf(csrf -> csrf.disable()) // 테스트를 위해 CSRF 보호 비활성화
+                .authorizeHttpRequests(auth -> auth
+                        // Swagger UI 및 관련 리소스 접근 허용
+                        .requestMatchers("/docs", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        // API 경로로 이어지는 접근 허용
+                        .requestMatchers("/api/**").permitAll()
+                        //기본 경로 접근 허용
+                        .requestMatchers("/").permitAll()
+                        // 그 외의 요청은 인증 필요하도록 설정
+                        .anyRequest().authenticated()
+                );
 
         return http.build();
     }

--- a/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.connecteamed.server.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -13,17 +14,38 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable()) // 테스트를 위해 CSRF 보호 비활성화
+                // 개발/테스트 편의용(운영에서는 정책에 맞게 재설정)
+                .csrf(csrf -> csrf.disable())
+                .cors(Customizer.withDefaults())
+
                 .authorizeHttpRequests(auth -> auth
-                        // Swagger UI 및 관련 리소스 접근 허용
-                        .requestMatchers("/docs", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        // API 경로로 이어지는 접근 허용
+                        // 기본/정적 리소스
+                        .requestMatchers(
+                                "/", "/index.html",
+                                "/document.html",
+                                "/css/**", "/js/**", "/images/**",
+                                "/favicon.ico",
+                                "/error"
+                        ).permitAll()
+
+                        // Swagger (springdoc)
+                        // swagger-ui.path=/docs 라면 /docs, /docs/** 둘 다 열어주는게 안전합니다.
+                        .requestMatchers(
+                                "/docs", "/docs/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+
+                        // API (테스트용 전체 오픈)
                         .requestMatchers("/api/**").permitAll()
-                        //기본 경로 접근 허용
-                        .requestMatchers("/").permitAll()
-                        // 그 외의 요청은 인증 필요하도록 설정
+
+                        // 그 외는 인증 필요
                         .anyRequest().authenticated()
-                );
+                )
+
+                // 리다이렉트/팝업 방지용(필요 없으면 제거 가능)
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable());
 
         return http.build();
     }

--- a/src/main/java/com/connecteamed/server/global/entity/BaseEntity.java
+++ b/src/main/java/com/connecteamed/server/global/entity/BaseEntity.java
@@ -9,7 +9,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.OffsetDateTime;
+import java.time.Instant;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
@@ -18,10 +18,10 @@ public abstract class BaseEntity {
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
-    private OffsetDateTime createdAt;
+    private Instant createdAt;
 
     @LastModifiedDate
     @Column(name="updated_at")
-    private OffsetDateTime updatedAt;
+    private Instant updatedAt;
 
 }

--- a/src/main/java/com/connecteamed/server/global/entity/BaseEntity.java
+++ b/src/main/java/com/connecteamed/server/global/entity/BaseEntity.java
@@ -17,7 +17,7 @@ import java.time.OffsetDateTime;
 public abstract class BaseEntity {
 
     @CreatedDate
-    @Column(name="created_at",nullable = false)
+    @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;
 
     @LastModifiedDate

--- a/src/main/java/com/connecteamed/server/global/entity/BaseEntity.java
+++ b/src/main/java/com/connecteamed/server/global/entity/BaseEntity.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import java.time.Instant;
+
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
@@ -17,7 +17,7 @@ import java.time.Instant;
 public abstract class BaseEntity {
 
     @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
+    @Column(name="created_at",nullable = false)
     private Instant createdAt;
 
     @LastModifiedDate

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,9 @@ spring:
   application:
     name: connecteamed-be
 
+  profiles:
+    active: local
+
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/connecteamed}
     username: ${DB_USERNAME:connecteamed}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,3 +20,10 @@ spring:
 
 server:
   port: 8080
+
+app:
+  s3:
+    region: ${APP_S3_REGION:ap-northeast-2}
+    bucket: ${APP_S3_BUCKET}
+    access-key: ${APP_S3_ACCESS_KEY}
+    secret-key: ${APP_S3_SECRET_KEY}

--- a/src/main/resources/static/document.html
+++ b/src/main/resources/static/document.html
@@ -1,0 +1,362 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Connected 문서 API 테스트</title>
+  <style>
+    :root { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    body { margin: 16px; line-height: 1.4; }
+    .row { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+    .card { border: 1px solid #ddd; border-radius: 10px; padding: 12px; margin: 12px 0; }
+    label { font-size: 12px; color: #444; display:block; margin-bottom: 4px; }
+    input, select, textarea, button {
+      font: inherit; border: 1px solid #ccc; border-radius: 8px; padding: 8px 10px;
+    }
+    input, select { min-width: 220px; }
+    textarea { width: 100%; min-height: 90px; }
+    button { cursor: pointer; }
+    button.primary { border-color:#111; background:#111; color:#fff; }
+    button.danger { border-color:#b00; background:#b00; color:#fff; }
+    .hint { font-size: 12px; color: #666; }
+    .out { white-space: pre-wrap; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; background:#fafafa; border:1px solid #eee; border-radius:10px; padding:10px; }
+    .small { min-width: 120px; }
+    .grow { flex: 1 1 auto; }
+  </style>
+</head>
+<body>
+  <h2>문서 API 테스트 페이지</h2>
+  <div class="hint">
+    같은 도메인에서 열면 CORS 이슈가 적습니다. 프론트 dev 서버에서 열거나, Spring에 정적 리소스로 넣어서 /test.html로 띄우는 걸 추천드립니다.
+  </div>
+
+  <div class="card">
+    <div class="row">
+      <div>
+        <label>Base URL</label>
+        <input id="baseUrl" class="grow" value="http://localhost:8080" />
+      </div>
+      <div>
+        <label>Access Token (Bearer 제외)</label>
+        <input id="token" class="grow" placeholder="eyJhbGciOi..." />
+      </div>
+    </div>
+
+    <div class="row" style="margin-top:10px">
+      <div>
+        <label>projectId</label>
+        <input id="projectId" class="small" placeholder="1" />
+      </div>
+      <div>
+        <label>projectMemberId</label>
+        <input id="projectMemberId" class="small" placeholder="11" />
+      </div>
+      <div>
+        <label>documentId</label>
+        <input id="documentId" class="small" placeholder="201" />
+      </div>
+      <button class="primary" id="btnHealth">GET /actuator/health</button>
+    </div>
+  </div>
+
+  <div class="card">
+    <h3>1) 문서 목록</h3>
+    <div class="row">
+      <button class="primary" id="btnList">GET /api/projects/{projectId}/documents</button>
+    </div>
+    <div class="hint">응답에 downloadUrl이 나오면, 파일 문서일 때 다운로드 버튼 테스트가 가능합니다.</div>
+  </div>
+
+  <div class="card">
+    <h3>2) 문서 상세</h3>
+    <div class="row">
+      <button class="primary" id="btnDetail">GET /api/documents/{documentId}</button>
+    </div>
+  </div>
+
+  <div class="card">
+    <h3>3) 텍스트 문서 생성</h3>
+    <div class="row">
+      <div class="grow">
+        <label>title</label>
+        <input id="createTitle" class="grow" placeholder="PRD 기획서" />
+      </div>
+    </div>
+    <div style="margin-top:10px">
+      <label>content (예: 에디터 HTML 문자열)</label>
+      <textarea id="createContent" placeholder="<h1>기획</h1><p>...</p>"></textarea>
+    </div>
+    <div class="row" style="margin-top:10px">
+      <button class="primary" id="btnCreateText">POST /api/projects/{projectId}/documents/text</button>
+    </div>
+  </div>
+
+  <div class="card">
+    <h3>4) 텍스트 문서 수정</h3>
+    <div class="row">
+      <div class="grow">
+        <label>title</label>
+        <input id="updateTitle" class="grow" placeholder="제목 수정" />
+      </div>
+    </div>
+    <div style="margin-top:10px">
+      <label>content</label>
+      <textarea id="updateContent" placeholder="<p>수정된 내용</p>"></textarea>
+    </div>
+    <div class="row" style="margin-top:10px">
+      <button class="primary" id="btnUpdateText">PATCH /api/documents/{documentId}</button>
+    </div>
+    <div class="hint">현재 API가 텍스트만 수정이라면 fileType=TEXT일 때만 성공하도록 백엔드에서 막는 게 일반적입니다.</div>
+  </div>
+
+  <div class="card">
+    <h3>5) 파일 업로드</h3>
+    <div class="row">
+      <div>
+        <label>type</label>
+        <select id="uploadType">
+          <option value="PDF">PDF</option>
+          <option value="DOCX">DOCX</option>
+          <option value="IMAGE">IMAGE</option>
+        </select>
+      </div>
+      <div>
+        <label>file</label>
+        <input id="uploadFile" type="file" />
+      </div>
+      <button class="primary" id="btnUpload">POST /api/projects/{projectId}/documents/upload</button>
+    </div>
+    <div class="hint">multipart/form-data: file(binary), type(PDF/DOCX/IMAGE)</div>
+  </div>
+
+  <div class="card">
+    <h3>6) 다운로드</h3>
+    <div class="row">
+      <button class="primary" id="btnDownload">GET /api/documents/{documentId}/download</button>
+    </div>
+    <div class="hint">서버가 파일(binary)을 내려주면 브라우저가 다운로드합니다.</div>
+  </div>
+
+  <div class="card">
+    <h3>7) 삭제</h3>
+    <div class="row">
+      <button class="danger" id="btnDelete">DELETE /api/documents/{documentId}</button>
+    </div>
+  </div>
+
+  <div class="card">
+    <h3>결과</h3>
+    <div class="out" id="out">여기에 응답이 표시됩니다.</div>
+  </div>
+
+<script>
+  const $ = (id) => document.getElementById(id);
+
+  function base() {
+    return ($("baseUrl").value || "").replace(/\/+$/, "");
+  }
+
+  function authHeaders() {
+    const token = $("token").value.trim();
+    const h = {};
+    if (token) h["Authorization"] = "Bearer " + token;
+    return h;
+  }
+
+  function mustNumber(id, name) {
+    const v = $(id).value.trim();
+    if (!v) throw new Error(name + " 값을 입력해주세요.");
+    const n = Number(v);
+    if (Number.isNaN(n)) throw new Error(name + "는 숫자여야 합니다.");
+    return n;
+  }
+
+  function setOut(obj) {
+    const out = $("out");
+    if (typeof obj === "string") out.textContent = obj;
+    else out.textContent = JSON.stringify(obj, null, 2);
+  }
+
+  async function req(method, url, { headers = {}, body } = {}) {
+    const res = await fetch(url, { method, headers, body });
+    const ct = res.headers.get("content-type") || "";
+
+    if (ct.includes("application/json")) {
+      const json = await res.json().catch(() => ({}));
+      return { ok: res.ok, status: res.status, headers: Object.fromEntries(res.headers), data: json };
+    }
+
+    const text = await res.text().catch(() => "");
+    return { ok: res.ok, status: res.status, headers: Object.fromEntries(res.headers), data: text };
+  }
+
+  async function reqBlob(url, headers = {}) {
+    const res = await fetch(url, { method: "GET", headers });
+    const blob = await res.blob();
+    return { res, blob };
+  }
+
+  // Health
+  $("btnHealth").addEventListener("click", async () => {
+    try {
+      setOut("요청 중...");
+      const url = base() + "/actuator/health";
+      const r = await req("GET", url, { headers: { ...authHeaders() } });
+      setOut(r);
+    } catch (e) { setOut(String(e)); }
+  });
+
+  // List
+  $("btnList").addEventListener("click", async () => {
+    try {
+      setOut("요청 중...");
+      const projectId = mustNumber("projectId", "projectId");
+      const url = base() + `/api/projects/${projectId}/documents`;
+      const r = await req("GET", url, { headers: { ...authHeaders() } });
+      setOut(r);
+    } catch (e) { setOut(String(e)); }
+  });
+
+  // Detail
+  $("btnDetail").addEventListener("click", async () => {
+    try {
+      setOut("요청 중...");
+      const documentId = mustNumber("documentId", "documentId");
+      const url = base() + `/api/documents/${documentId}`;
+      const r = await req("GET", url, { headers: { ...authHeaders() } });
+      setOut(r);
+    } catch (e) { setOut(String(e)); }
+  });
+
+  // Create text
+  $("btnCreateText").addEventListener("click", async () => {
+    try {
+      setOut("요청 중...");
+      const projectId = mustNumber("projectId", "projectId");
+      const projectMemberId = mustNumber("projectMemberId", "projectMemberId");
+
+      const url = base() + `/api/projects/${projectId}/documents/text`;
+
+      const payload = {
+        projectMemberId,
+        title: $("createTitle").value.trim(),
+        content: $("createContent").value
+      };
+
+      const r = await req("POST", url, {
+        headers: {
+          ...authHeaders(),
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      });
+
+      setOut(r);
+    } catch (e) { setOut(String(e)); }
+  });
+
+  // Update text
+  $("btnUpdateText").addEventListener("click", async () => {
+    try {
+      setOut("요청 중...");
+      const documentId = mustNumber("documentId", "documentId");
+      const projectMemberId = mustNumber("projectMemberId", "projectMemberId");
+
+      const url = base() + `/api/documents/${documentId}`;
+
+      const payload = {
+        projectMemberId,
+        title: $("updateTitle").value.trim(),
+        content: $("updateContent").value
+      };
+
+      const r = await req("PATCH", url, {
+        headers: {
+          ...authHeaders(),
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      });
+
+      setOut(r);
+    } catch (e) { setOut(String(e)); }
+  });
+
+  // Upload file
+  $("btnUpload").addEventListener("click", async () => {
+    try {
+      setOut("요청 중...");
+      const projectId = mustNumber("projectId", "projectId");
+      const projectMemberId = mustNumber("projectMemberId", "projectMemberId");
+
+      const f = $("uploadFile").files && $("uploadFile").files[0];
+      if (!f) throw new Error("업로드할 파일을 선택해주세요.");
+
+      const url = base() + `/api/projects/${projectId}/documents/upload`;
+
+      const form = new FormData();
+      form.append("projectMemberId", String(projectMemberId));
+      form.append("type", $("uploadType").value);
+      form.append("file", f);
+
+      const r = await req("POST", url, {
+        headers: { ...authHeaders() },
+        body: form
+      });
+
+      setOut(r);
+    } catch (e) { setOut(String(e)); }
+  });
+
+  // Download
+  $("btnDownload").addEventListener("click", async () => {
+    try {
+      setOut("요청 중...");
+      const documentId = mustNumber("documentId", "documentId");
+      const url = base() + `/api/documents/${documentId}/download`;
+
+      const { res, blob } = await reqBlob(url, { ...authHeaders() });
+
+      if (!res.ok) {
+        const text = await blob.text().catch(() => "");
+        setOut({ ok: false, status: res.status, error: text });
+        return;
+      }
+
+      const cd = res.headers.get("content-disposition") || "";
+      let filename = "download";
+      const m = cd.match(/filename\*?=(?:UTF-8''|")?([^\";]+)"?/i);
+      if (m && m[1]) filename = decodeURIComponent(m[1]);
+
+      const a = document.createElement("a");
+      a.href = URL.createObjectURL(blob);
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(a.href);
+
+      setOut({ ok: true, status: res.status, message: "다운로드 시작됨", filename });
+    } catch (e) { setOut(String(e)); }
+  });
+
+  // Delete
+  $("btnDelete").addEventListener("click", async () => {
+    try {
+      setOut("요청 중...");
+      const documentId = mustNumber("documentId", "documentId");
+      const projectMemberId = mustNumber("projectMemberId", "projectMemberId");
+
+      const url = base() + `/api/documents/${documentId}`;
+
+      // DELETE에 body를 허용하지 않는 서버/프록시도 있어서 query로 보냅니다.
+      // 백엔드가 body로 받게 되어 있으면 여기만 맞춰 바꿔주세요.
+      const u = url + `?projectMemberId=${encodeURIComponent(projectMemberId)}`;
+
+      const r = await req("DELETE", u, { headers: { ...authHeaders() } });
+      setOut(r);
+    } catch (e) { setOut(String(e)); }
+  });
+</script>
+</body>
+</html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Connecteamed - Home</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 24px; }
+    .wrap { max-width: 720px; margin: 0 auto; }
+    a.button { display: inline-block; padding: 10px 14px; border: 1px solid #ddd; border-radius: 8px; text-decoration: none; }
+    a.button:hover { background: #f5f5f5; }
+    ul { padding-left: 18px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Connecteamed</h1>
+    <p>테스트용 정적 메인 페이지입니다.</p>
+
+    <p>
+      <a class="button" href="/document.html">문서 테스트 페이지로 이동</a>
+    </p>
+
+    <h3>바로가기</h3>
+    <ul>
+      <li><a href="/document.html">/document.html</a></li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/src/test/java/com/connecteamed/server/domain/document/service/DocumentServiceImplTest.java
+++ b/src/test/java/com/connecteamed/server/domain/document/service/DocumentServiceImplTest.java
@@ -1,0 +1,165 @@
+package com.connecteamed.server.domain.document.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.connecteamed.server.domain.document.dto.DocumentCreateRes;
+import com.connecteamed.server.domain.document.dto.DocumentCreateTextReq;
+import com.connecteamed.server.domain.document.dto.DocumentUploadRes;
+import com.connecteamed.server.domain.document.entity.Document;
+import com.connecteamed.server.domain.document.enums.DocumentFileType;
+import com.connecteamed.server.domain.document.repository.DocumentRepository;
+import com.connecteamed.server.domain.project.entity.Project;
+import com.connecteamed.server.domain.project.entity.ProjectMember;
+import com.connecteamed.server.domain.project.repository.ProjectMemberRepository;
+import com.connecteamed.server.domain.project.repository.ProjectRepository;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentServiceImplTest {
+
+    @Mock ProjectRepository projectRepository;
+    @Mock ProjectMemberRepository projectMemberRepository;
+    @Mock DocumentRepository documentRepository;
+    @Mock S3StorageService s3StorageService; // 인터페이스/구현명 맞추세요
+
+    @InjectMocks DocumentServiceImpl documentService; // 실제 서비스 구현 클래스명 맞추세요
+
+    @Test
+    @DisplayName("텍스트 문서 생성: 프로젝트/멤버 참조 후 저장하고 응답을 반환한다")
+    void createText_success() {
+        // given
+        Long projectId = 1L;
+        Long projectMemberId = 1L;
+        var req = new DocumentCreateTextReq("제목", "내용");
+
+        Project projectRef = mock(Project.class);
+        ProjectMember memberRef = mock(ProjectMember.class);
+
+        given(projectRepository.getReferenceById(projectId)).willReturn(projectRef);
+        given(projectMemberRepository.getReferenceById(projectMemberId)).willReturn(memberRef);
+
+        // save될 Document의 id/createdAt이 필요하므로, save 시점에 값을 세팅해주는 방식으로 처리
+        given(documentRepository.save(any(Document.class))).willAnswer(invocation -> {
+            Document d = invocation.getArgument(0);
+            // 테스트용으로 리플렉션 대신, Document 엔티티가 id/createdAt getter를 제대로 반환한다고 가정
+            ReflectionTestUtils.setField(d, "id", 1L);
+            ReflectionTestUtils.setField(d, "createdAt", OffsetDateTime.now());
+            return d;
+        });
+
+        // when
+        DocumentCreateRes res = documentService.createText(projectId, projectMemberId, req);
+
+        // then
+        // save가 호출됐는지 + 저장된 Document의 필드가 기대대로인지 확인
+        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+        then(documentRepository).should().save(captor.capture());
+
+        Document saved = captor.getValue();
+        assertThat(saved.getFileType()).isEqualTo(DocumentFileType.TEXT);
+        assertThat(saved.getTitle()).isEqualTo("제목");
+        assertThat(saved.getContent()).isEqualTo("내용");
+        assertThat(saved.getFileUrl()).isNull();
+
+        // 응답 검증(프로젝트 상황에 따라 createdAt이 null일 수 있음)
+        assertThat(res).isNotNull();
+    }
+
+    @Test
+    @DisplayName("파일 업로드: type이 TEXT면 예외")
+    void uploadFile_rejectTextType() {
+        // given
+        MultipartFile file = new MockMultipartFile(
+                "file", "a.txt", "text/plain", "hello".getBytes()
+        );
+
+        // when + then
+        assertThatThrownBy(() -> documentService.uploadFile(1L, 1L, file, DocumentFileType.TEXT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("TEXT는 파일 업로드 타입이 아닙니다");
+
+        then(s3StorageService).shouldHaveNoInteractions();
+        then(documentRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("파일 업로드: S3 업로드 후 Document 저장하고 응답 반환")
+    void uploadFile_success() {
+        // given
+        Long projectId = 1L;
+        Long projectMemberId = 1L;
+
+        MultipartFile file = new MockMultipartFile(
+                "file",
+                "image.png",
+                "image/png",
+                new byte[] {1,2,3}
+        );
+
+        Project projectRef = mock(Project.class);
+        ProjectMember memberRef = mock(ProjectMember.class);
+
+        given(projectRepository.getReferenceById(projectId)).willReturn(projectRef);
+        given(projectMemberRepository.getReferenceById(projectMemberId)).willReturn(memberRef);
+
+        // 여기서 s3StorageService.upload가 key를 반환하도록
+        given(s3StorageService.upload(eq(file), eq("project-" + projectId)))
+                .willReturn("documents/project-1/uuid_image.png");
+
+        // documentRepository.save가 저장된 엔티티를 반환하도록(필요하면 id/createdAt 가정)
+        given(documentRepository.save(any(Document.class))).willAnswer(invocation -> {
+            Document d = invocation.getArgument(0);
+
+            ReflectionTestUtils.setField(d, "id", 1L);
+            ReflectionTestUtils.setField(d, "createdAt", OffsetDateTime.now());
+
+            return d;
+        
+        });
+
+        // when
+        DocumentUploadRes res = documentService.uploadFile(projectId, projectMemberId, file, DocumentFileType.IMAGE);
+
+        // then
+        then(s3StorageService).should().upload(eq(file), eq("project-" + projectId));
+        then(documentRepository).should().save(any(Document.class));
+
+        assertThat(res).isNotNull();
+        assertThat(res.fileName()).isEqualTo("image.png");
+    }
+
+    @Test
+    @DisplayName("다운로드: TEXT 문서는 다운로드 대상이 아니므로 예외")
+    void download_rejectTextDocument() {
+        // given
+        Document textDoc = mock(Document.class);
+        given(textDoc.getFileType()).willReturn(DocumentFileType.TEXT);
+
+        given(documentRepository.findByIdAndDeletedAtIsNull(10L))
+                .willReturn(Optional.of(textDoc));
+
+        // when + then
+        assertThatThrownBy(() -> documentService.download(10L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("TEXT 문서는 다운로드 대상이 아닙니다.");
+    }
+}


### PR DESCRIPTION
## 📌 PR 요약
- 문서(Document) 도메인 기능(목록/상세/업로드/텍스트생성/수정/삭제/다운로드) 구현 및 공통 응답 포맷 적용
- JPA Auditing(BaseEntity) 적용으로 createdAt/updatedAt 자동 관리
- S3 연동(업로드/다운로드) 구성 및 환경설정 정리
- Validation 및 전역 예외 처리(요청 검증 메시지 반환) 보강
- Swagger(springdoc) 및 SecurityConfig에서 Swagger/정적 리소스 접근 허용 경로 정리

## 🔧 변경 사항
- ApiResponse + Success/Error Code 기반으로 API 응답 형식을 통일해 프론트/문서화에서 일관성 확보
- @Valid 기반 DTO 검증 실패 시 기존 500으로 떨어지던 문제를 BAD_REQUEST로 내려가도록 전역 예외 처리 보완
- S3 업로드 시 key 저장 방식으로 정리하고, 다운로드는 key 기반으로 S3에서 스트리밍하도록 수정하여 500 오류 해결
- Swagger UI 로딩 실패 이슈 대응을 위해 springdoc 버전/보안 설정 경로를 정리하고 접근 가능하도록 설정

## 📋 작업 상세 내용
- [x] DocumentController API 응답 ApiResponse.onSuccess 적용 및 상태코드(OK/CREATED) 정리
- [x] Document 텍스트 생성 DTO에 @NotBlank + 컨트롤러 @Valid 적용
- [x] GeneralExceptionAdvice에 MethodArgumentNotValidException 처리 추가(검증 메시지 응답 반영)
- [x] JPA Auditing 활성화 및 BaseEntity(createdAt/updatedAt: OffsetDateTime) 적용
- [x] S3Config 구성(app.s3.* 프로퍼티 사용) 및 S3StorageService 업로드/다운로드 흐름 정리
- [x] 문서 다운로드 로직을 URL 직접 접근 방식에서 S3 key 기반 스트리밍 방식으로 수정(500 해결)
- [x] SecurityConfig에 정적 리소스/Swagger 경로 permitAll 및 formLogin/httpBasic disable로 리다이렉트 방지
- [x] build.gradle springdoc-openapi-starter-webmvc-ui 버전 업데이트 반영


- DocumentServiceImpl 단위 테스트 및 contextLoads 포함 전체 테스트 통과
<img width="1269" height="222" alt="Screenshot 2026-01-14 at 2 16 21 PM" src="https://github.com/user-attachments/assets/f50853c2-e2de-40cf-9111-756a6d2edbdc" />

- 테스트 리포트(build/reports/tests/test/index.html)에서 전체 테스트 통과
<img width="2444" height="334" alt="Screenshot 2026-01-14 at 2 28 45 PM" src="https://github.com/user-attachments/assets/944459af-dbee-4dc6-b487-ad5ba8703b28" />



## 🔗 관련 이슈
- closed #5 

## 📝 기타
- S3 파일 삭제는 DB 소프트삭제와 별개로 동작하도록 두었으며, 추후 정책(즉시 삭제/지연 삭제/라이프사이클) 논의 가능
- Swagger 접속 경로: /docs (설정 기준) / swagger-ui 경로도 함께 허용 처리됨

## 📝 리뷰 포인트 / 미구현 사항

- 인증 연동 전이라 projectMemberId를 임시값(1L)로 고정해서 사용 중입니다.
  - 목적: 문서 CRUD/S3 연동/응답 포맷/검증 로직을 먼저 완성하고 기능 흐름을 검증하기 위함
  - 후속 작업: JWT/세션에서 memberId를 추출한 뒤, project_member 테이블을 조회하여 projectMemberId를 동적으로 매핑하고 프로젝트 멤버 여부/권한(작성자, 소유자 등) 검증 로직을 추가할 예정입니다.

## ✅ 예외 처리 개선 사항
- 현재 공통 응답 포맷(ApiResponse + GeneralErrorCode)을 유지하면서, 클라이언트가 원인을 이해할 수 있는 메시지를 내려주도록 정리했습니다.

