### PR TITLE
[FEAT] task API

### DIFF
--- a/src/main/java/com/connecteamed/server/domain/task/controller/CompletedTaskController.java
+++ b/src/main/java/com/connecteamed/server/domain/task/controller/CompletedTaskController.java
@@ -1,0 +1,59 @@
+package com.connecteamed.server.domain.task.controller;
+
+import com.connecteamed.server.domain.task.dto.CompletedTaskDetailRes;
+import com.connecteamed.server.domain.task.dto.CompletedTaskListRes;
+import com.connecteamed.server.domain.task.dto.CompletedTaskStatusUpdateReq;
+import com.connecteamed.server.domain.task.dto.CompletedTaskUpdateReq;
+import com.connecteamed.server.domain.task.service.CompletedTaskService;
+import com.connecteamed.server.global.apiPayload.ApiResponse;
+import com.connecteamed.server.global.apiPayload.code.GeneralSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "완료한 업무 API", description = "완료한 업무 목록/상세 조회 및 회고 관리 API")
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CompletedTaskController {
+
+    private final CompletedTaskService completedTaskService;
+
+    @Operation(summary = "1. 완료한 업무 목록 조회", description = "프로젝트 내 상태가 DONE인 업무 리스트를 반환합니다.")
+    @GetMapping("/projects/{projectId}/tasks/completed")
+    public ApiResponse<CompletedTaskListRes> getCompletedTasks(@PathVariable Long projectId) {
+        return ApiResponse.onSuccess(GeneralSuccessCode._OK, completedTaskService.getCompletedTasks(projectId));
+    }
+
+    @Operation(summary = "2. 완료한 업무 상태 변경", description = "업무의 진행 상태를 변경합니다.")
+    @PatchMapping("/tasks/{taskId}/status")
+    public ApiResponse<String> updateTaskStatus(
+            @PathVariable Long taskId,
+            @RequestBody CompletedTaskStatusUpdateReq req) {
+        completedTaskService.updateCompletedTaskStatus(taskId, req.status());
+        return ApiResponse.onSuccess(GeneralSuccessCode._OK, null,"업무 상태가 변경되었습니다.");
+    }
+
+    @Operation(summary = "3. 완료한 업무 상세 조회", description = "업무 상세 정보와 작성한 회고 내용을 조회합니다.")
+    @GetMapping("/tasks/{taskId}")
+    public ApiResponse<CompletedTaskDetailRes> getCompletedTaskDetail(@PathVariable Long taskId) {
+        return ApiResponse.onSuccess(GeneralSuccessCode._OK, completedTaskService.getCompletedTaskDetail(taskId));
+    }
+
+    @Operation(summary = "4. 완료한 업무 상세 수정 및 회고 저장", description = "업무 정보 수정 및 회고를 저장합니다.")
+    @PatchMapping("/tasks/{taskId}")
+    public ApiResponse<String> updateCompletedTask(
+            @PathVariable Long taskId,
+            @RequestBody CompletedTaskUpdateReq req) {
+        completedTaskService.updateCompletedTask(taskId, req);
+        return ApiResponse.onSuccess(GeneralSuccessCode._OK, null,"업무 정보 및 회고가 수정되었습니다.");
+    }
+
+    @Operation(summary = "5. 완료한 업무 삭제", description = "업무를 Soft Delete 합니다.")
+    @DeleteMapping("/tasks/{taskId}")
+    public ApiResponse<String> deleteCompletedTask(@PathVariable Long taskId) {
+        completedTaskService.deleteCompletedTask(taskId);
+        return ApiResponse.onSuccess(GeneralSuccessCode._OK, null,"업무가 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/connecteamed/server/domain/task/controller/CompletedTaskController.java
+++ b/src/main/java/com/connecteamed/server/domain/task/controller/CompletedTaskController.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "완료한 업무 API", description = "완료한 업무 목록/상세 조회 및 회고 관리 API")
+@Tag(name = "Completed Task", description = "완료한 업무 목록/상세 조회 및 회고 관리 API")
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -20,13 +20,13 @@ public class CompletedTaskController {
 
     private final CompletedTaskService completedTaskService;
 
-    @Operation(summary = "1. 완료한 업무 목록 조회", description = "프로젝트 내 상태가 DONE인 업무 리스트를 반환합니다.")
+    @Operation(summary = "완료한 업무 목록 조회", description = "프로젝트 내 상태가 DONE인 업무 리스트를 반환합니다.")
     @GetMapping("/projects/{projectId}/tasks/completed")
     public ApiResponse<CompletedTaskListRes> getCompletedTasks(@PathVariable Long projectId) {
         return ApiResponse.onSuccess(GeneralSuccessCode._OK, completedTaskService.getCompletedTasks(projectId));
     }
 
-    @Operation(summary = "2. 완료한 업무 상태 변경", description = "업무의 진행 상태를 변경합니다.")
+    @Operation(summary = "완료한 업무 상태 변경", description = "업무의 진행 상태를 변경합니다.")
     @PatchMapping("/tasks/{taskId}/status")
     public ApiResponse<String> updateTaskStatus(
             @PathVariable Long taskId,
@@ -35,13 +35,13 @@ public class CompletedTaskController {
         return ApiResponse.onSuccess(GeneralSuccessCode._OK, null,"업무 상태가 변경되었습니다.");
     }
 
-    @Operation(summary = "3. 완료한 업무 상세 조회", description = "업무 상세 정보와 작성한 회고 내용을 조회합니다.")
+    @Operation(summary = "완료한 업무 상세 조회", description = "업무 상세 정보와 작성한 회고 내용을 조회합니다.")
     @GetMapping("/tasks/{taskId}")
     public ApiResponse<CompletedTaskDetailRes> getCompletedTaskDetail(@PathVariable Long taskId) {
         return ApiResponse.onSuccess(GeneralSuccessCode._OK, completedTaskService.getCompletedTaskDetail(taskId));
     }
 
-    @Operation(summary = "4. 완료한 업무 상세 수정 및 회고 저장", description = "업무 정보 수정 및 회고를 저장합니다.")
+    @Operation(summary = "완료한 업무 상세 수정 및 회고 저장", description = "업무 정보 수정 및 회고를 저장합니다.")
     @PatchMapping("/tasks/{taskId}")
     public ApiResponse<String> updateCompletedTask(
             @PathVariable Long taskId,
@@ -50,7 +50,7 @@ public class CompletedTaskController {
         return ApiResponse.onSuccess(GeneralSuccessCode._OK, null,"업무 정보 및 회고가 수정되었습니다.");
     }
 
-    @Operation(summary = "5. 완료한 업무 삭제", description = "업무를 Soft Delete 합니다.")
+    @Operation(summary = "완료한 업무 삭제", description = "업무를 Soft Delete 합니다.")
     @DeleteMapping("/tasks/{taskId}")
     public ApiResponse<String> deleteCompletedTask(@PathVariable Long taskId) {
         completedTaskService.deleteCompletedTask(taskId);

--- a/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskDetailRes.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskDetailRes.java
@@ -1,0 +1,14 @@
+package com.connecteamed.server.domain.task.dto;
+
+import java.util.List;
+
+public record CompletedTaskDetailRes (
+        Long taskId,
+        String name,
+        String content,
+        String startDate,
+        String dueDate,
+        String status,
+        List<String> assigneeNames,
+        String noteContent
+) {}

--- a/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskDetailRes.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskDetailRes.java
@@ -1,13 +1,14 @@
 package com.connecteamed.server.domain.task.dto;
 
+import java.time.Instant;
 import java.util.List;
 
 public record CompletedTaskDetailRes (
         Long taskId,
         String name,
         String content,
-        String startDate,
-        String dueDate,
+        Instant startDate,
+        Instant dueDate,
         String status,
         List<String> assigneeNames,
         String noteContent

--- a/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskListRes.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskListRes.java
@@ -1,5 +1,6 @@
 package com.connecteamed.server.domain.task.dto;
 
+import java.time.Instant;
 import java.util.List;
 
 public record CompletedTaskListRes(
@@ -9,8 +10,8 @@ public record CompletedTaskListRes(
             Long taskId,
             String name,
             String content,
-            String startDate,
-            String dueDate,
+            Instant startDate,
+            Instant dueDate,
             String status,
             List<String> assigneeNames
     ) {}

--- a/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskListRes.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskListRes.java
@@ -2,7 +2,7 @@ package com.connecteamed.server.domain.task.dto;
 
 import java.util.List;
 
-public record TaskListRes (
+public record CompletedTaskListRes(
         List<TaskSummary> tasks
 ) {
     public record TaskSummary(

--- a/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskStatusUpdateReq.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskStatusUpdateReq.java
@@ -1,0 +1,7 @@
+package com.connecteamed.server.domain.task.dto;
+
+import com.connecteamed.server.domain.task.enums.TaskStatus;
+
+public record CompletedTaskStatusUpdateReq (
+        TaskStatus status
+) {}

--- a/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskStatusUpdateReq.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskStatusUpdateReq.java
@@ -1,7 +1,9 @@
 package com.connecteamed.server.domain.task.dto;
 
 import com.connecteamed.server.domain.task.enums.TaskStatus;
+import jakarta.validation.constraints.NotNull;
 
 public record CompletedTaskStatusUpdateReq (
+        @NotNull
         TaskStatus status
 ) {}

--- a/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskUpdateReq.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskUpdateReq.java
@@ -1,0 +1,7 @@
+package com.connecteamed.server.domain.task.dto;
+
+public record CompletedTaskUpdateReq (
+    String name,
+    String content,
+    String noteContent
+) {}

--- a/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskUpdateReq.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/CompletedTaskUpdateReq.java
@@ -1,7 +1,13 @@
 package com.connecteamed.server.domain.task.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record CompletedTaskUpdateReq (
+    @NotBlank(message = "업무 이름은 비워둘 수 없습니다.")
     String name,
+    @NotNull(message = "업무 내용은 null일 수 없습니다.")
     String content,
+    @NotNull(message = "회고 내용은 null일 수 없습니다.")
     String noteContent
 ) {}

--- a/src/main/java/com/connecteamed/server/domain/task/dto/TaskListRes.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/TaskListRes.java
@@ -1,0 +1,17 @@
+package com.connecteamed.server.domain.task.dto;
+
+import java.util.List;
+
+public record TaskListRes (
+        List<TaskSummary> tasks
+) {
+    public record TaskSummary(
+            Long taskId,
+            String name,
+            String content,
+            String startDate,
+            String dueDate,
+            String status,
+            List<String> assigneeNames
+    ) {}
+}

--- a/src/main/java/com/connecteamed/server/domain/task/entity/Task.java
+++ b/src/main/java/com/connecteamed/server/domain/task/entity/Task.java
@@ -48,6 +48,19 @@ public class Task extends BaseEntity {
     @Column(name="deleted_at")
     private OffsetDateTime deletedAt;
 
+    public void updateStatus(TaskStatus status) {
+        this.status = status;
+    }
+
+    public void updateInfo(String name, String content) {
+        this.name = name;
+        this.content = content;
+    }
+
+    public void softDelete() {
+        this.deletedAt = OffsetDateTime.now();
+    }
+
     @PrePersist
     public void prePersist(){
         if(this.publicId == null){

--- a/src/main/java/com/connecteamed/server/domain/task/entity/Task.java
+++ b/src/main/java/com/connecteamed/server/domain/task/entity/Task.java
@@ -6,6 +6,7 @@ import com.connecteamed.server.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
@@ -40,13 +41,13 @@ public class Task extends BaseEntity {
     private TaskStatus status=TaskStatus.TODO;
 
     @Column(name="start_date",nullable = false)
-    private OffsetDateTime startDate;
+    private Instant startDate;
 
     @Column(name="due_date",nullable = false)
-    private OffsetDateTime dueDate;
+    private Instant dueDate;
 
     @Column(name="deleted_at")
-    private OffsetDateTime deletedAt;
+    private Instant deletedAt;
 
     public void updateStatus(TaskStatus status) {
         this.status = status;
@@ -58,7 +59,7 @@ public class Task extends BaseEntity {
     }
 
     public void softDelete() {
-        this.deletedAt = OffsetDateTime.now();
+        this.deletedAt = java.time.Instant.now();
     }
 
     @PrePersist

--- a/src/main/java/com/connecteamed/server/domain/task/entity/TaskNote.java
+++ b/src/main/java/com/connecteamed/server/domain/task/entity/TaskNote.java
@@ -26,4 +26,8 @@ public class TaskNote extends BaseEntity {
 
     @Column(name="content",nullable = false,columnDefinition = "TEXT")
     private String content;
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/connecteamed/server/domain/task/repository/TaskAssigneeRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/task/repository/TaskAssigneeRepository.java
@@ -1,5 +1,6 @@
 package com.connecteamed.server.domain.task.repository;
 
+import com.connecteamed.server.domain.task.entity.Task;
 import com.connecteamed.server.domain.task.entity.TaskAssignee;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +8,6 @@ import java.util.List;
 
 public interface TaskAssigneeRepository extends JpaRepository<TaskAssignee,Long> {
     List<TaskAssignee> findAllByTaskId(Long taskId);
+
+    List<TaskAssignee> findAllByTaskIdIn(List<Long> taskIds);
 }

--- a/src/main/java/com/connecteamed/server/domain/task/repository/TaskAssigneeRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/task/repository/TaskAssigneeRepository.java
@@ -1,0 +1,10 @@
+package com.connecteamed.server.domain.task.repository;
+
+import com.connecteamed.server.domain.task.entity.TaskAssignee;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TaskAssigneeRepository extends JpaRepository<TaskAssignee,Long> {
+    List<TaskAssignee> findAllByTaskId(Long taskId);
+}

--- a/src/main/java/com/connecteamed/server/domain/task/repository/TaskNoteRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/task/repository/TaskNoteRepository.java
@@ -1,0 +1,10 @@
+package com.connecteamed.server.domain.task.repository;
+
+import com.connecteamed.server.domain.task.entity.TaskNote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TaskNoteRepository extends JpaRepository<TaskNote, Long> {
+    Optional<TaskNote> findByTaskIdAndTaskAssignee_ProjectMember_Id(Long taskId, Long projectMemberId);
+}

--- a/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
@@ -1,4 +1,11 @@
 package com.connecteamed.server.domain.task.repository;
 
-public class TaskRepository {
+import com.connecteamed.server.domain.task.entity.Task;
+import com.connecteamed.server.domain.task.enums.TaskStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TaskRepository extends JpaRepository<Task,Long> {
+    List<Task> findAllByProjectIdAndStatusAndDeletedAtIsNull(Long projectId, TaskStatus status);
 }

--- a/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
@@ -47,8 +47,8 @@ public class CompletedTaskService {
                             task.getId(),
                             task.getName(),
                             task.getContent(),
-                            task.getStartDate().toString(),
-                            task.getDueDate().toString(),
+                            task.getStartDate(),
+                            task.getDueDate(),
                             task.getStatus().name(),
                             assigneeNames
                     );
@@ -77,8 +77,8 @@ public class CompletedTaskService {
                 task.getId(),
                 task.getName(),
                 task.getContent(),
-                task.getStartDate().toString(),
-                task.getDueDate().toString(),
+                task.getStartDate(),
+                task.getDueDate(),
                 task.getStatus().name(),
                 assigneeNames,
                 myNote
@@ -111,7 +111,14 @@ public class CompletedTaskService {
     }
 
     private TaskNote createNewNote(Task task) {
-        TaskAssignee assignee = taskAssigneeRepository.findAllByTaskId(task.getId()).get(0);
+        List<TaskAssignee> assignees = taskAssigneeRepository.findAllByTaskId(task.getId());
+
+        if (assignees.isEmpty()) {
+            throw new RuntimeException("해당 업무에 할당된 담당자가 없어 회고를 작성할 수 없습니다.");
+        }
+
+        TaskAssignee assignee = assignees.get(0);
+
         return taskNoteRepository.save(TaskNote.builder()
                 .task(task)
                 .taskAssignee(assignee)

--- a/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
@@ -75,13 +75,15 @@ public class CompletedTaskService {
     // 완료한 업무 상태 변경
     @Transactional
     public void updateCompletedTaskStatus(Long taskId, TaskStatus taskStatus) {
-        Task task = taskRepository.findById(taskId).orElseThrow();
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new RuntimeException("해당 ID의 업무를 찾을 수 없습니다."));
         task.updateStatus(taskStatus);
     }
 
     // 완료한 업무 상세 조회
     public CompletedTaskDetailRes getCompletedTaskDetail(Long taskId) {
-        Task task = taskRepository.findById(taskId).orElseThrow();
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new RuntimeException("해당 ID의 업무를 찾을 수 없습니다."));
 
         List<String> assigneeNames = getAssigneeNames(taskId);
 
@@ -107,7 +109,7 @@ public class CompletedTaskService {
     @Transactional
     public void updateCompletedTask(Long taskId, CompletedTaskUpdateReq req) {
         Task task = taskRepository.findById(taskId)
-                .orElseThrow(() -> new RuntimeException("업무를 찾을 수 없습니다."));
+                .orElseThrow(() -> new RuntimeException("해당 ID의 업무를 찾을 수 없습니다."));
         task.updateInfo(req.name(), req.content());
 
         Long currentMemberId = getCurrentUserId();
@@ -121,7 +123,8 @@ public class CompletedTaskService {
     // 완료한 업무 삭제
     @Transactional
     public void deleteCompletedTask(Long taskId) {
-        Task task = taskRepository.findById(taskId).orElseThrow();
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new RuntimeException("해당 ID의 업무를 찾을 수 없습니다."));
         task.softDelete();
     }
 

--- a/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
@@ -1,0 +1,56 @@
+package com.connecteamed.server.domain.task.service;
+
+import com.connecteamed.server.domain.task.dto.TaskListRes;
+import com.connecteamed.server.domain.task.entity.Task;
+import com.connecteamed.server.domain.task.enums.TaskStatus;
+import com.connecteamed.server.domain.task.repository.TaskAssigneeRepository;
+import com.connecteamed.server.domain.task.repository.TaskRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CompletedTaskService {
+
+    private final TaskRepository taskRepository;
+    private final TaskAssigneeRepository taskAssigneeRepository;
+
+    @Value("${app.test.user-id:1}")
+    private Long testUserId;
+
+    // 완료된 업무 목록 조회
+    public TaskListRes getCompletedTasks(Long projectId) {
+        List<Task> completedTasks = taskRepository.findAllByProjectIdAndStatusAndDeletedAtIsNull(
+                projectId,
+                TaskStatus.DONE
+        );
+
+        List<TaskListRes.TaskSummary> summaries = completedTasks.stream()
+                .map(task -> {
+                    List<String> assigneeNames = taskAssigneeRepository.findAllByTaskId(task.getId())
+                            .stream()
+                            .map(assignee -> assignee.getProjectMember().getMember().getName())
+                            .toList();
+
+                    return new TaskListRes.TaskSummary(
+                            task.getId(),
+                            task.getName(),
+                            task.getContent(),
+                            task.getStartDate().toString(),
+                            task.getDueDate().toString(),
+                            task.getStatus().name(),
+                            assigneeNames
+                    );
+                }).toList();
+        return new TaskListRes(summaries);
+    }
+
+    private Long getCurrentUserId() {
+        return testUserId;
+    }
+}

--- a/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
@@ -11,6 +11,8 @@ import com.connecteamed.server.domain.task.enums.TaskStatus;
 import com.connecteamed.server.domain.task.repository.TaskAssigneeRepository;
 import com.connecteamed.server.domain.task.repository.TaskNoteRepository;
 import com.connecteamed.server.domain.task.repository.TaskRepository;
+import com.connecteamed.server.global.apiPayload.code.GeneralErrorCode;
+import com.connecteamed.server.global.apiPayload.exception.GeneralException;
 import com.connecteamed.server.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -76,14 +78,14 @@ public class CompletedTaskService {
     @Transactional
     public void updateCompletedTaskStatus(Long taskId, TaskStatus taskStatus) {
         Task task = taskRepository.findById(taskId)
-                .orElseThrow(() -> new RuntimeException("해당 ID의 업무를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND, "해당 ID의 업무를 찾을 수 없습니다."));
         task.updateStatus(taskStatus);
     }
 
     // 완료한 업무 상세 조회
     public CompletedTaskDetailRes getCompletedTaskDetail(Long taskId) {
         Task task = taskRepository.findById(taskId)
-                .orElseThrow(() -> new RuntimeException("해당 ID의 업무를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND, "해당 ID의 업무를 찾을 수 없습니다."));
 
         List<String> assigneeNames = getAssigneeNames(taskId);
 
@@ -109,7 +111,7 @@ public class CompletedTaskService {
     @Transactional
     public void updateCompletedTask(Long taskId, CompletedTaskUpdateReq req) {
         Task task = taskRepository.findById(taskId)
-                .orElseThrow(() -> new RuntimeException("해당 ID의 업무를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND, "해당 ID의 업무를 찾을 수 없습니다."));
         task.updateInfo(req.name(), req.content());
 
         Long currentMemberId = getCurrentUserId();
@@ -124,7 +126,7 @@ public class CompletedTaskService {
     @Transactional
     public void deleteCompletedTask(Long taskId) {
         Task task = taskRepository.findById(taskId)
-                .orElseThrow(() -> new RuntimeException("해당 ID의 업무를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND, "해당 ID의 업무를 찾을 수 없습니다."));
         task.softDelete();
     }
 
@@ -138,7 +140,7 @@ public class CompletedTaskService {
         TaskAssignee assignee = taskAssigneeRepository.findAllByTaskId(task.getId()).stream()
                 .filter(a -> a.getProjectMember().getMember().getId().equals(memberId))
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException("해당 업무의 담당자가 아니므로 노트를 작성할 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.FORBIDDEN, "해당 업무의 담당자가 아니므로 노트를 작성할 수 없습니다."));
 
         return taskNoteRepository.save(TaskNote.builder()
                 .task(task)
@@ -150,7 +152,7 @@ public class CompletedTaskService {
     private Long getCurrentUserId() {
         String loginId = SecurityUtil.getCurrentLoginId();
         return memberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new RuntimeException("인증된 사용자 정보를 찾을 수 없습니다."))
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.UNAUTHORIZED, "인증된 사용자 정보를 찾을 수 없습니다."))
                 .getId();
     }
 }

--- a/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
@@ -1,6 +1,6 @@
 package com.connecteamed.server.domain.task.service;
 
-import com.connecteamed.server.domain.task.dto.TaskListRes;
+import com.connecteamed.server.domain.task.dto.CompletedTaskListRes;
 import com.connecteamed.server.domain.task.entity.Task;
 import com.connecteamed.server.domain.task.enums.TaskStatus;
 import com.connecteamed.server.domain.task.repository.TaskAssigneeRepository;
@@ -24,20 +24,20 @@ public class CompletedTaskService {
     private Long testUserId;
 
     // 완료된 업무 목록 조회
-    public TaskListRes getCompletedTasks(Long projectId) {
+    public CompletedTaskListRes getCompletedTasks(Long projectId) {
         List<Task> completedTasks = taskRepository.findAllByProjectIdAndStatusAndDeletedAtIsNull(
                 projectId,
                 TaskStatus.DONE
         );
 
-        List<TaskListRes.TaskSummary> summaries = completedTasks.stream()
+        List<CompletedTaskListRes.TaskSummary> summaries = completedTasks.stream()
                 .map(task -> {
                     List<String> assigneeNames = taskAssigneeRepository.findAllByTaskId(task.getId())
                             .stream()
                             .map(assignee -> assignee.getProjectMember().getMember().getName())
                             .toList();
 
-                    return new TaskListRes.TaskSummary(
+                    return new CompletedTaskListRes.TaskSummary(
                             task.getId(),
                             task.getName(),
                             task.getContent(),
@@ -47,7 +47,7 @@ public class CompletedTaskService {
                             assigneeNames
                     );
                 }).toList();
-        return new TaskListRes(summaries);
+        return new CompletedTaskListRes(summaries);
     }
 
     private Long getCurrentUserId() {

--- a/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
@@ -1,9 +1,14 @@
 package com.connecteamed.server.domain.task.service;
 
+import com.connecteamed.server.domain.task.dto.CompletedTaskDetailRes;
 import com.connecteamed.server.domain.task.dto.CompletedTaskListRes;
+import com.connecteamed.server.domain.task.dto.CompletedTaskUpdateReq;
 import com.connecteamed.server.domain.task.entity.Task;
+import com.connecteamed.server.domain.task.entity.TaskAssignee;
+import com.connecteamed.server.domain.task.entity.TaskNote;
 import com.connecteamed.server.domain.task.enums.TaskStatus;
 import com.connecteamed.server.domain.task.repository.TaskAssigneeRepository;
+import com.connecteamed.server.domain.task.repository.TaskNoteRepository;
 import com.connecteamed.server.domain.task.repository.TaskRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,11 +24,12 @@ public class CompletedTaskService {
 
     private final TaskRepository taskRepository;
     private final TaskAssigneeRepository taskAssigneeRepository;
+    private final TaskNoteRepository taskNoteRepository;
 
     @Value("${app.test.user-id:1}")
     private Long testUserId;
 
-    // 완료된 업무 목록 조회
+    // 완료한 업무 목록 조회
     public CompletedTaskListRes getCompletedTasks(Long projectId) {
         List<Task> completedTasks = taskRepository.findAllByProjectIdAndStatusAndDeletedAtIsNull(
                 projectId,
@@ -48,6 +54,69 @@ public class CompletedTaskService {
                     );
                 }).toList();
         return new CompletedTaskListRes(summaries);
+    }
+
+    // 완료한 업무 상태 변경
+    @Transactional
+    public void updateCompletedTaskStatus(Long taskId, TaskStatus taskStatus) {
+        Task task = taskRepository.findById(taskId).orElseThrow();
+        task.updateStatus(taskStatus);
+    }
+
+    // 완료한 업무 상세 조회
+    public CompletedTaskDetailRes getCompletedTaskDetail(Long taskId) {
+        Task task = taskRepository.findById(taskId).orElseThrow();
+
+        List<String> assigneeNames = getAssigneeNames(taskId);
+
+        String myNote = taskNoteRepository.findByTaskIdAndTaskAssignee_ProjectMember_Id(taskId, testUserId)
+                .map(TaskNote::getContent)
+                .orElse("");
+
+        return new CompletedTaskDetailRes(
+                task.getId(),
+                task.getName(),
+                task.getContent(),
+                task.getStartDate().toString(),
+                task.getDueDate().toString(),
+                task.getStatus().name(),
+                assigneeNames,
+                myNote
+        );
+    }
+
+    // 완료한 업무 상세 수정
+    @Transactional
+    public void updateCompletedTask(Long taskId, CompletedTaskUpdateReq req) {
+        Task task = taskRepository.findById(taskId).orElseThrow();
+        task.updateInfo(req.name(), req.content());
+
+        TaskNote note = taskNoteRepository.findByTaskIdAndTaskAssignee_ProjectMember_Id(taskId, testUserId)
+                .orElseGet(() -> createNewNote(task));
+
+        note.updateContent(req.noteContent());
+    }
+
+    // 완료한 업무 삭제
+    @Transactional
+    public void deleteCompletedTask(Long taskId) {
+        Task task = taskRepository.findById(taskId).orElseThrow();
+        task.softDelete();
+    }
+
+    private List<String> getAssigneeNames(Long taskId) {
+        return taskAssigneeRepository.findAllByTaskId(taskId).stream()
+                .map(a -> a.getProjectMember().getMember().getName())
+                .toList();
+    }
+
+    private TaskNote createNewNote(Task task) {
+        TaskAssignee assignee = taskAssigneeRepository.findAllByTaskId(task.getId()).get(0);
+        return taskNoteRepository.save(TaskNote.builder()
+                .task(task)
+                .taskAssignee(assignee)
+                .content("")
+                .build());
     }
 
     private Long getCurrentUserId() {

--- a/src/test/java/com/connecteamed/server/domain/task/controller/CompletedTaskControllerTest.java
+++ b/src/test/java/com/connecteamed/server/domain/task/controller/CompletedTaskControllerTest.java
@@ -1,0 +1,144 @@
+package com.connecteamed.server.domain.task.controller;
+
+import com.connecteamed.server.domain.task.dto.CompletedTaskListRes;
+import com.connecteamed.server.domain.task.dto.CompletedTaskStatusUpdateReq;
+import com.connecteamed.server.domain.task.dto.CompletedTaskUpdateReq;
+import com.connecteamed.server.domain.task.enums.TaskStatus;
+import com.connecteamed.server.domain.task.service.CompletedTaskService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class CompletedTaskControllerTest {
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private CompletedTaskService completedTaskService;
+
+    @InjectMocks
+    private CompletedTaskController completedTaskController;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(completedTaskController)
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .setValidator(validator)
+                .build();
+    }
+
+    @Test
+    @DisplayName("GET /api/projects/{projectId}/tasks/completed 는 200과 목록을 반환한다")
+    void getCompletedTasks_ok() throws Exception {
+        when(completedTaskService.getCompletedTasks(1L)).thenReturn(new CompletedTaskListRes(List.of()));
+
+        mockMvc.perform(get("/api/projects/{projectId}/tasks/completed", 1L))
+                .andExpect(status().isOk());
+
+        verify(completedTaskService, times(1)).getCompletedTasks(1L);
+    }
+
+    @Test
+    @DisplayName("PATCH /api/tasks/{taskId}/status 는 상태 변경 후 200을 반환한다")
+    void updateTaskStatus_ok() throws Exception {
+        CompletedTaskStatusUpdateReq req = new CompletedTaskStatusUpdateReq(TaskStatus.DONE);
+        String content = objectMapper.writeValueAsString(req);
+
+        mockMvc.perform(patch("/api/tasks/{taskId}/status", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("업무 상태가 변경되었습니다."));
+
+        verify(completedTaskService, times(1)).updateCompletedTaskStatus(eq(1L), any());
+    }
+
+    @Test
+    @DisplayName("GET /api/tasks/{taskId} 는 상세 정보와 200을 반환한다")
+    void getCompletedTaskDetail_ok() throws Exception {
+        when(completedTaskService.getCompletedTaskDetail(1L)).thenReturn(null);
+
+        mockMvc.perform(get("/api/tasks/{taskId}", 1L))
+                .andExpect(status().isOk());
+
+        verify(completedTaskService, times(1)).getCompletedTaskDetail(1L);
+    }
+
+    @Test
+    @DisplayName("PATCH /api/tasks/{taskId} 는 수정 성공 시 200을 반환한다")
+    void updateCompletedTask_ok() throws Exception {
+        CompletedTaskUpdateReq req = new CompletedTaskUpdateReq("수정 제목", "수정 내용", "회고 내용");
+        String content = objectMapper.writeValueAsString(req);
+
+        mockMvc.perform(patch("/api/tasks/{taskId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("업무 정보 및 회고가 수정되었습니다."));
+
+        verify(completedTaskService, times(1)).updateCompletedTask(eq(1L), any(CompletedTaskUpdateReq.class));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/tasks/{taskId} 는 삭제 성공 시 200을 반환한다")
+    void deleteCompletedTask_ok() throws Exception {
+        mockMvc.perform(delete("/api/tasks/{taskId}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("업무가 삭제되었습니다."));
+
+        verify(completedTaskService, times(1)).deleteCompletedTask(1L);
+    }
+
+    @Test
+    @DisplayName("PATCH status: JSON이 깨져있으면 400을 반환한다")
+    void updateTaskStatus_invalidJson_badRequest() throws Exception {
+        mockMvc.perform(
+                        patch("/api/tasks/{taskId}/status", 1L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"status\":\"DON")
+                )
+                .andExpect(status().isBadRequest());
+
+        verify(completedTaskService, never()).updateCompletedTaskStatus(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("PATCH tasks: Body가 아예 비어있으면 400을 반환한다")
+    void updateCompletedTask_invalidBody_badRequest() throws Exception {
+        mockMvc.perform(
+                        patch("/api/tasks/{taskId}", 1L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("")
+                )
+                .andExpect(status().isBadRequest());
+
+        verify(completedTaskService, never()).updateCompletedTask(anyLong(), any());
+    }
+}

--- a/src/test/java/com/connecteamed/server/domain/task/service/CompletedTaskServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/task/service/CompletedTaskServiceTest.java
@@ -1,0 +1,91 @@
+package com.connecteamed.server.domain.task.service;
+
+import com.connecteamed.server.domain.task.dto.CompletedTaskDetailRes;
+import com.connecteamed.server.domain.task.entity.Task;
+import com.connecteamed.server.domain.task.entity.TaskNote;
+import com.connecteamed.server.domain.task.enums.TaskStatus;
+import com.connecteamed.server.domain.task.repository.TaskAssigneeRepository;
+import com.connecteamed.server.domain.task.repository.TaskNoteRepository;
+import com.connecteamed.server.domain.task.repository.TaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+class CompletedTaskServiceTest {
+
+    @InjectMocks
+    private CompletedTaskService completedTaskService;
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    @Mock
+    private TaskAssigneeRepository taskAssigneeRepository;
+
+    @Mock
+    private TaskNoteRepository taskNoteRepository;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(completedTaskService, "testUserId", 1L);
+    }
+
+    @Test
+    @DisplayName("완료 업무 상세 조회 시 내 회고 내용이 포함되어야 한다")
+    void getCompletedTaskDetail_Success() {
+        // given
+        Long taskId = 1L;
+        Task task = Task.builder()
+                .id(taskId)
+                .name("테스트 업무")
+                .content("내용")
+                .status(TaskStatus.DONE)
+                .startDate(java.time.Instant.now())
+                .dueDate(java.time.Instant.now())
+                .build();
+
+        TaskNote note = TaskNote.builder().content("나의 회고록").build();
+
+        given(taskRepository.findById(taskId)).willReturn(Optional.of(task));
+        given(taskNoteRepository.findByTaskIdAndTaskAssignee_ProjectMember_Id(anyLong(), anyLong()))
+                .willReturn(Optional.of(note));
+
+        // when
+        CompletedTaskDetailRes result = completedTaskService.getCompletedTaskDetail(taskId);
+
+        // then
+        assertThat(result.noteContent()).isEqualTo("나의 회고록");
+        verify(taskNoteRepository, times(1)).findByTaskIdAndTaskAssignee_ProjectMember_Id(taskId, 1L);
+    }
+
+    @Test
+    @DisplayName("업무 삭제 호출 시 실제로 삭제되지 않고 deletedAt 필드만 채워져야 한다 (Soft Delete)")
+    void deleteCompletedTask_SoftDelete() {
+        // given
+        Long taskId = 1L;
+        Task task = spy(Task.builder()
+                .id(taskId)
+                .status(TaskStatus.DONE)
+                .build());
+
+        given(taskRepository.findById(taskId)).willReturn(Optional.of(task));
+
+        // when
+        completedTaskService.deleteCompletedTask(taskId);
+
+        // then
+        verify(task).softDelete();
+        assertThat(task.getDeletedAt()).isNotNull();
+    }
+}


### PR DESCRIPTION
## 📌 PR 요약
- 완료 업무 도메인 기능(목록/상세 조회/상태 변경/수정/삭제) 구현
- Swagger 연동을 통한 API 명세 자동화
- Mockito 및 MockMvc 기반 단위 테스트 작성으로 API 및 서비스 로직 검증

## 🔧 변경 사항
- 응답 규격 및 Soft Delete 적용: 업무 삭제 시 실제 삭제가 아닌 deletedAt 필드를 활용한 Soft Delete 로직 구현
- 시간 데이터 타입 통일: 엔티티 및 DTO의 시간 타입을 Instant로 통일

## 📋 작업 상세 내용
- [x] CompletedTaskController API 구현: 목록 조회, 상세 조회, 수정, 삭제 등 총 5개의 API 구현
- [x] Swagger 문서화: 각 API별 @Operation 적용 및 상세 설명 추가
- [x] MockitoExtension 및 StandaloneSetup을 활용하여 빠른 테스트 환경 구축

- 목록/상세/수정/삭제 성공 및 JSON 파싱 에러, 필수값 누락 등 400 에러 실패 케이스 검증 완료
<img width="906" height="118" alt="image" src="https://github.com/user-attachments/assets/66f7c5d9-b084-4b12-a5aa-8d76313fd8e3" />


## 🔗 관련 이슈
- closed #19 

## 📝 기타