### PR TITLE
[FEAT] project task API

### DIFF
--- a/src/main/java/com/connecteamed/server/domain/document/controller/DocumentController.java
+++ b/src/main/java/com/connecteamed/server/domain/document/controller/DocumentController.java
@@ -1,7 +1,5 @@
 package com.connecteamed.server.domain.document.controller;
 
-import java.net.ResponseCache;
-
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;

--- a/src/main/java/com/connecteamed/server/domain/document/controller/DocumentController.java
+++ b/src/main/java/com/connecteamed/server/domain/document/controller/DocumentController.java
@@ -24,6 +24,7 @@ import com.connecteamed.server.domain.document.service.DocumentService;
 import com.connecteamed.server.global.apiPayload.ApiResponse;
 import com.connecteamed.server.global.apiPayload.code.GeneralSuccessCode;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 
 @RestController
@@ -36,25 +37,25 @@ public class DocumentController {
         this.documentService = documentService;
     }
 
-    // 문서 목록 조회
+    @Operation(summary = "문서 목록 조회", description = "문서 목록의 조회하는 API입니다.")
     @GetMapping("/projects/{projectId}/documents")
     public ApiResponse<DocumentListRes> list(@PathVariable Long projectId) {
         return ApiResponse.onSuccess(GeneralSuccessCode._OK, documentService.list(projectId));
     }
 
-    // 문서 상세 조회(모달)
+    @Operation(summary = "문서 상세 조회", description = "문서를 상세를 조회하는 API입니다.")
     @GetMapping("/documents/{documentId}")
     public ApiResponse<DocumentDetailRes> detail(@PathVariable Long documentId) {
         return ApiResponse.onSuccess(GeneralSuccessCode._OK, documentService.detail(documentId));
     }
 
-    // 문서 다운로드(바이너리)
+    @Operation(summary = "문서 다운로드", description = "문서 다운로드 API입니다.")
     @GetMapping("/documents/{documentId}/download")
     public ResponseEntity<Resource> download(@PathVariable Long documentId) {
         return documentService.download(documentId);
     }
 
-    // 문서 추가(파일 업로드)
+    @Operation(summary = "문서 추가(파일 업로드)", description = "문서 추가 (파일 업로드) API입니다.")
     @PostMapping(value = "/projects/{projectId}/documents/upload", consumes = "multipart/form-data")
     public ApiResponse<DocumentUploadRes> upload(
             @PathVariable Long projectId,
@@ -66,7 +67,7 @@ public class DocumentController {
         return ApiResponse.onSuccess(GeneralSuccessCode._CREATED, documentService.uploadFile(projectId, projectMemberId, file, fileType));
     }
 
-    // 문서 추가(텍스트 작성)
+    @Operation(summary = "문서 추가(텍스트 작성)", description = "문서 추가 (텍스트 작성) API입니다.")
     @PostMapping("/projects/{projectId}/documents/text")
     public ApiResponse<DocumentCreateRes> createText(
             @PathVariable Long projectId,
@@ -76,7 +77,7 @@ public class DocumentController {
         return ApiResponse.onSuccess(GeneralSuccessCode._CREATED, documentService.createText(projectId, projectMemberId, req));
     }
 
-    // 문서 수정(텍스트만)
+    @Operation(summary = "문서 수정(텍스트)", description = "문서수정(텍스트) API입니다.")
     @PatchMapping("/documents/{documentId}")
     public ApiResponse<Void> updateText(
             @PathVariable Long documentId,
@@ -87,7 +88,7 @@ public class DocumentController {
         return ApiResponse.onSuccess(GeneralSuccessCode._OK, null);
     }
 
-    // 문서 삭제(소프트 삭제)
+    @Operation(summary = "문서 삭제", description = "문서삭제 API입니다.")
     @DeleteMapping("/documents/{documentId}")
     public ApiResponse<Void> delete(@PathVariable Long documentId) {
         Long projectMemberId = 1L; // TODO 인증에서 꺼내오기

--- a/src/main/java/com/connecteamed/server/domain/document/controller/DocumentController.java
+++ b/src/main/java/com/connecteamed/server/domain/document/controller/DocumentController.java
@@ -1,5 +1,7 @@
 package com.connecteamed.server.domain.document.controller;
 
+import java.net.ResponseCache;
+
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -41,14 +43,18 @@ public class DocumentController {
 
     @Operation(summary = "문서 목록 조회", description = "문서 목록의 조회하는 API입니다.")
     @GetMapping("/projects/{projectId}/documents")
-    public ApiResponse<DocumentListRes> list(@PathVariable Long projectId) {
-        return ApiResponse.onSuccess(GeneralSuccessCode._OK, documentService.list(projectId));
+    public ResponseEntity<ApiResponse<DocumentListRes>> list(@PathVariable Long projectId) {
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(GeneralSuccessCode._OK, documentService.list(projectId))
+        );
     }
 
     @Operation(summary = "문서 상세 조회", description = "문서를 상세를 조회하는 API입니다.")
     @GetMapping("/documents/{documentId}")
-    public ApiResponse<DocumentDetailRes> detail(@PathVariable Long documentId) {
-        return ApiResponse.onSuccess(GeneralSuccessCode._OK, documentService.detail(documentId));
+    public ResponseEntity<ApiResponse<DocumentDetailRes>> detail(@PathVariable Long documentId) {
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(GeneralSuccessCode._OK, documentService.detail(documentId))
+        );
     }
 
     @Operation(summary = "문서 다운로드", description = "문서 다운로드 API입니다.")
@@ -59,43 +65,51 @@ public class DocumentController {
 
     @Operation(summary = "문서 추가(파일 업로드)", description = "문서 추가 (파일 업로드) API입니다.")
     @PostMapping(value = "/projects/{projectId}/documents/upload", consumes = "multipart/form-data")
-    public ApiResponse<DocumentUploadRes> upload(
+    public ResponseEntity<ApiResponse<DocumentUploadRes>> upload(
             @PathVariable Long projectId,
             @RequestPart("file") MultipartFile file,
             @RequestPart("type") String type
     ) {
         Long projectMemberId = 1L; // TODO 인증에서 꺼내오기
         DocumentFileType fileType = DocumentFileType.valueOf(type);
-        return ApiResponse.onSuccess(GeneralSuccessCode._CREATED, documentService.uploadFile(projectId, projectMemberId, file, fileType));
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(GeneralSuccessCode._CREATED, documentService.uploadFile(projectId, projectMemberId, file, fileType))
+        );
     }
 
     @Operation(summary = "문서 추가(텍스트 작성)", description = "문서 추가 (텍스트 작성) API입니다.")
     @PostMapping("/projects/{projectId}/documents/text")
-    public ApiResponse<DocumentCreateRes> createText(
+    public ResponseEntity<ApiResponse<DocumentCreateRes>> createText(
             @PathVariable Long projectId,
             @Valid @RequestBody DocumentCreateTextReq req
     ) {
         Long projectMemberId = 1L; // TODO 인증에서 꺼내오기
-        return ApiResponse.onSuccess(GeneralSuccessCode._CREATED, documentService.createText(projectId, projectMemberId, req));
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(GeneralSuccessCode._CREATED, documentService.createText(projectId, projectMemberId, req))
+        );
     }
 
     @Operation(summary = "문서 수정(텍스트)", description = "문서수정(텍스트) API입니다.")
     @PatchMapping("/documents/{documentId}")
-    public ApiResponse<Void> updateText(
+    public ResponseEntity<ApiResponse<Void>> updateText(
             @PathVariable Long documentId,
             @RequestBody DocumentUpdateTextReq req
     ) {
         Long projectMemberId = 1L; // TODO 인증에서 꺼내오기
         documentService.updateText(documentId, projectMemberId, req);
-        return ApiResponse.onSuccess(GeneralSuccessCode._OK, null);
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(GeneralSuccessCode._OK, null)
+        );
     }
 
     @Operation(summary = "문서 삭제", description = "문서삭제 API입니다.")
     @DeleteMapping("/documents/{documentId}")
-    public ApiResponse<Void> delete(@PathVariable Long documentId) {
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long documentId) {
         Long projectMemberId = 1L; // TODO 인증에서 꺼내오기
         documentService.delete(documentId, projectMemberId);
-        return ApiResponse.onSuccess(GeneralSuccessCode._OK, null);
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(GeneralSuccessCode._OK, null)
+        );
     }
 
 }

--- a/src/main/java/com/connecteamed/server/domain/document/controller/DocumentController.java
+++ b/src/main/java/com/connecteamed/server/domain/document/controller/DocumentController.java
@@ -25,10 +25,12 @@ import com.connecteamed.server.global.apiPayload.ApiResponse;
 import com.connecteamed.server.global.apiPayload.code.GeneralSuccessCode;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api")
+@Tag(name = "Document", description = "문서 관련 API")
 public class DocumentController {
 
     private final DocumentService documentService;

--- a/src/main/java/com/connecteamed/server/domain/project/controller/ProjectMemberController.java
+++ b/src/main/java/com/connecteamed/server/domain/project/controller/ProjectMemberController.java
@@ -12,11 +12,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/projects/{projectId}")
+@Tag(name = "Project-Member", description = "팀원 & 역할 관련 API")
 public class ProjectMemberController {
 
     private final ProjectMemberService projectMemberService;

--- a/src/main/java/com/connecteamed/server/domain/project/controller/ProjectMemberController.java
+++ b/src/main/java/com/connecteamed/server/domain/project/controller/ProjectMemberController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 
 @RestController
@@ -20,14 +21,14 @@ public class ProjectMemberController {
 
     private final ProjectMemberService projectMemberService;
 
-    // 프로젝트별 팀원 목록 & 역할
+    @Operation(summary = "프로젝트별 팀원 목록&역할", description = "프로젝트별 팀원 목록&역할 조회 API입니다.")
     @GetMapping("/members")
     public ResponseEntity<ApiResponse<List<ProjectMemberRes>>> getMembers(@PathVariable Long projectId) {
         List<ProjectMemberRes> res = projectMemberService.getProjectMembers(projectId);
         return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, res));
     }
 
-    // 팀원 역할 할당(교체)
+    @Operation(summary = "팀원 역할 할당(교체)", description = "팀원 역할 할당(교체) API입니다.")
     @PatchMapping("/members/{projectMemberId}/roles")
     public ResponseEntity<ApiResponse<ProjectMemberRes>> updateRoles(
             @PathVariable Long projectId,
@@ -38,7 +39,7 @@ public class ProjectMemberController {
         return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, res));
     }
 
-    // 프로젝트 역할 목록 조회 (project_required_role 기반)
+    @Operation(summary = "프로젝트 역할 목록 조회", description = "프로젝트 역할 목록 조회 API입니다.")
     @GetMapping("/roles")
     public ResponseEntity<ApiResponse<ProjectRoleListRes>> getProjectRoles(@PathVariable Long projectId) {
         return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, projectMemberService.getProjectRoles(projectId)));

--- a/src/main/java/com/connecteamed/server/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/project/repository/ProjectMemberRepository.java
@@ -14,4 +14,7 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
 
     @EntityGraph(attributePaths = {"member", "roles", "roles.role"})
     Optional<ProjectMember> findByIdAndProjectId(Long id, Long projectId);
+
+    @EntityGraph(attributePaths = {"member", "roles", "roles.role"})
+    List<ProjectMember> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/connecteamed/server/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/project/repository/ProjectMemberRepository.java
@@ -17,8 +17,8 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
     Optional<ProjectMember> findByIdAndProjectId(Long id, Long projectId);
 
     @EntityGraph(attributePaths = {"member", "roles", "roles.role"})
-    List<ProjectMember> findAllByIdIn(List<Long> ids);\
-      
+    List<ProjectMember> findAllByIdIn(List<Long> ids);
+
     @EntityGraph(attributePaths = {"project", "roles", "roles.role"})
     List<ProjectMember> findAllByMember(Member member);
 

--- a/src/main/java/com/connecteamed/server/domain/task/controller/CompletedTaskController.java
+++ b/src/main/java/com/connecteamed/server/domain/task/controller/CompletedTaskController.java
@@ -26,7 +26,6 @@ public class CompletedTaskController {
         return ApiResponse.onSuccess(GeneralSuccessCode._OK, completedTaskService.getCompletedTasks(projectId));
     }
 
-    //TODO: updateTaskStatus 중복-> CompletedTaskController
     @Operation(summary = "완료한 업무 상태 변경", description = "업무의 진행 상태를 변경합니다.")
     @PatchMapping("/tasks/{taskId}/status")
     public ApiResponse<String> updateTaskStatus(

--- a/src/main/java/com/connecteamed/server/domain/task/controller/CompletedTaskController.java
+++ b/src/main/java/com/connecteamed/server/domain/task/controller/CompletedTaskController.java
@@ -26,6 +26,7 @@ public class CompletedTaskController {
         return ApiResponse.onSuccess(GeneralSuccessCode._OK, completedTaskService.getCompletedTasks(projectId));
     }
 
+    //TODO: updateTaskStatus 중복-> CompletedTaskController
     @Operation(summary = "완료한 업무 상태 변경", description = "업무의 진행 상태를 변경합니다.")
     @PatchMapping("/tasks/{taskId}/status")
     public ApiResponse<String> updateTaskStatus(

--- a/src/main/java/com/connecteamed/server/domain/task/controller/TaskController.java
+++ b/src/main/java/com/connecteamed/server/domain/task/controller/TaskController.java
@@ -44,7 +44,7 @@ public class TaskController {
     }
 
     @Operation(summary = "업무 상세 조회", description = "업무 상세 조회 API입니다.")
-    @GetMapping("/tasks/{taskId}")
+    @GetMapping("/tasks/{taskId}/detail")
     public ResponseEntity<ApiResponse<TaskDetailRes>> getTaskDetail(
             @PathVariable UUID taskId
     ) {
@@ -53,18 +53,19 @@ public class TaskController {
         );
     }
 
-    @Operation(summary = "업무 상태 변경", description = "업무 상태 변경 API입니다.")
-    @PatchMapping("/tasks/{taskId}/status")
-    public ResponseEntity<ApiResponse<Void>> updateTaskStatus(
-            @PathVariable UUID taskId,
-            @RequestBody @Valid TaskStatusUpdateReq req
-    ) {
-        taskService.updateTaskStatus(taskId, req);
-        return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, null));
-    }
+    //TODO: updateTaskStatus 중복-> TaskController
+    // @Operation(summary = "업무 상태 변경", description = "업무 상태 변경 API입니다.")
+    // @PatchMapping("/tasks/{taskId}/status")
+    // public ResponseEntity<ApiResponse<Void>> updateTaskStatus(
+    //         @PathVariable UUID taskId,
+    //         @RequestBody @Valid TaskStatusUpdateReq req
+    // ) {
+    //     taskService.updateTaskStatus(taskId, req);
+    //     return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, null));
+    // }
 
     @Operation(summary = "업무 일정 수정(시작/마감)", description = "업무 일정 수정(시작/마감) API입니다.")
-    @PatchMapping("/tasks/{taskId}")
+    @PatchMapping("/tasks/{taskId}/schedule")
     public ResponseEntity<ApiResponse<Void>> updateTaskSchedule(
             @PathVariable UUID taskId,
             @RequestBody @Valid TaskScheduleUpdateReq req
@@ -83,12 +84,12 @@ public class TaskController {
         return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, null));
     }
 
-    @Operation(summary = "업무 삭제(soft delete)", description = "업무 삭제(soft delete) API입니다.")
-    @DeleteMapping("/tasks/{taskId}")
-    public ResponseEntity<ApiResponse<Void>> deleteTask(
-            @PathVariable UUID taskId
-    ) {
-        taskService.deleteTask(taskId);
-        return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, null));
-    }
+    // @Operation(summary = "업무 삭제(soft delete)", description = "업무 삭제(soft delete) API입니다.")
+    // @DeleteMapping("/tasks/{taskId}")
+    // public ResponseEntity<ApiResponse<Void>> deleteTask(
+    //         @PathVariable UUID taskId
+    // ) {
+    //     taskService.deleteTask(taskId);
+    //     return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, null));
+    // }
 }

--- a/src/main/java/com/connecteamed/server/domain/task/controller/TaskController.java
+++ b/src/main/java/com/connecteamed/server/domain/task/controller/TaskController.java
@@ -84,6 +84,7 @@ public class TaskController {
         return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, null));
     }
 
+    // TODO: 업무 삭제 CompletedTaskController 중복 해결 필요
     // @Operation(summary = "업무 삭제(soft delete)", description = "업무 삭제(soft delete) API입니다.")
     // @DeleteMapping("/tasks/{taskId}")
     // public ResponseEntity<ApiResponse<Void>> deleteTask(

--- a/src/main/java/com/connecteamed/server/domain/task/controller/TaskController.java
+++ b/src/main/java/com/connecteamed/server/domain/task/controller/TaskController.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
 
 import java.util.List;
 import java.util.Map;
@@ -20,7 +21,7 @@ public class TaskController {
 
     private final TaskService taskService;
 
-    // 업무 추가
+    @Operation(summary = "업무 추가", description = "업무 추가 API입니다.")
     @PostMapping("/projects/{projectId}/tasks")
     public ResponseEntity<ApiResponse<Map<String, Object>>> createTask(
             @PathVariable Long projectId,
@@ -32,7 +33,7 @@ public class TaskController {
         );
     }
 
-    // 업무 목록 조회(전체)
+    @Operation(summary = "업무 목록 조회(전체)", description = "업무 목록 조회(전체) API입니다.")
     @GetMapping("/projects/{projectId}/tasks")
     public ResponseEntity<ApiResponse<List<TaskSummaryRes>>> getProjectTasks(
             @PathVariable Long projectId
@@ -42,7 +43,7 @@ public class TaskController {
         );
     }
 
-    // 업무 상세 조회
+    @Operation(summary = "업무 상세 조회", description = "업무 상세 조회 API입니다.")
     @GetMapping("/tasks/{taskId}")
     public ResponseEntity<ApiResponse<TaskDetailRes>> getTaskDetail(
             @PathVariable UUID taskId
@@ -52,7 +53,7 @@ public class TaskController {
         );
     }
 
-    // 업무 상태 변경(드롭다운)
+    @Operation(summary = "업무 상태 변경", description = "업무 상태 변경 API입니다.")
     @PatchMapping("/tasks/{taskId}/status")
     public ResponseEntity<ApiResponse<Void>> updateTaskStatus(
             @PathVariable UUID taskId,
@@ -62,7 +63,7 @@ public class TaskController {
         return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, null));
     }
 
-    // 업무 일정 수정(시작/마감)
+    @Operation(summary = "업무 일정 수정(시작/마감)", description = "업무 일정 수정(시작/마감) API입니다.")
     @PatchMapping("/tasks/{taskId}")
     public ResponseEntity<ApiResponse<Void>> updateTaskSchedule(
             @PathVariable UUID taskId,
@@ -72,7 +73,7 @@ public class TaskController {
         return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, null));
     }
 
-    // 담당자 변경(전체 교체)
+    @Operation(summary = "담당자 변경(전체 교체)", description = "담당자 변경(전체 교체) API입니다.")
     @PatchMapping("/tasks/{taskId}/assignees")
     public ResponseEntity<ApiResponse<Void>> updateTaskAssignees(
             @PathVariable UUID taskId,
@@ -82,7 +83,7 @@ public class TaskController {
         return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, null));
     }
 
-    // 업무 삭제(soft delete)
+    @Operation(summary = "업무 삭제(soft delete)", description = "업무 삭제(soft delete) API입니다.")
     @DeleteMapping("/tasks/{taskId}")
     public ResponseEntity<ApiResponse<Void>> deleteTask(
             @PathVariable UUID taskId

--- a/src/main/java/com/connecteamed/server/domain/task/controller/TaskController.java
+++ b/src/main/java/com/connecteamed/server/domain/task/controller/TaskController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 import java.util.Map;
@@ -17,6 +18,7 @@ import java.util.UUID;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "Project-Task", description = "프로젝트 업무 관련 API")
 public class TaskController {
 
     private final TaskService taskService;

--- a/src/main/java/com/connecteamed/server/domain/task/controller/TaskController.java
+++ b/src/main/java/com/connecteamed/server/domain/task/controller/TaskController.java
@@ -1,4 +1,93 @@
 package com.connecteamed.server.domain.task.controller;
 
+import com.connecteamed.server.domain.task.dto.*;
+import com.connecteamed.server.domain.task.service.TaskService;
+import com.connecteamed.server.global.apiPayload.ApiResponse;
+import com.connecteamed.server.global.apiPayload.code.GeneralSuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
 public class TaskController {
+
+    private final TaskService taskService;
+
+    // 업무 추가
+    @PostMapping("/projects/{projectId}/tasks")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> createTask(
+            @PathVariable Long projectId,
+            @RequestBody @Valid TaskCreateReq req
+    ) {
+        UUID taskId = taskService.createTask(projectId, req);
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(GeneralSuccessCode._OK, Map.of("taskId", taskId))
+        );
+    }
+
+    // 업무 목록 조회(전체)
+    @GetMapping("/projects/{projectId}/tasks")
+    public ResponseEntity<ApiResponse<List<TaskSummaryRes>>> getProjectTasks(
+            @PathVariable Long projectId
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(GeneralSuccessCode._OK, taskService.getProjectTasks(projectId))
+        );
+    }
+
+    // 업무 상세 조회
+    @GetMapping("/tasks/{taskId}")
+    public ResponseEntity<ApiResponse<TaskDetailRes>> getTaskDetail(
+            @PathVariable UUID taskId
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(GeneralSuccessCode._OK, taskService.getTaskDetail(taskId))
+        );
+    }
+
+    // 업무 상태 변경(드롭다운)
+    @PatchMapping("/tasks/{taskId}/status")
+    public ResponseEntity<ApiResponse<Void>> updateTaskStatus(
+            @PathVariable UUID taskId,
+            @RequestBody @Valid TaskStatusUpdateReq req
+    ) {
+        taskService.updateTaskStatus(taskId, req);
+        return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, null));
+    }
+
+    // 업무 일정 수정(시작/마감)
+    @PatchMapping("/tasks/{taskId}")
+    public ResponseEntity<ApiResponse<Void>> updateTaskSchedule(
+            @PathVariable UUID taskId,
+            @RequestBody @Valid TaskScheduleUpdateReq req
+    ) {
+        taskService.updateTaskSchedule(taskId, req);
+        return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, null));
+    }
+
+    // 담당자 변경(전체 교체)
+    @PatchMapping("/tasks/{taskId}/assignees")
+    public ResponseEntity<ApiResponse<Void>> updateTaskAssignees(
+            @PathVariable UUID taskId,
+            @RequestBody @Valid TaskAssigneeUpdateReq req
+    ) {
+        taskService.updateTaskAssignees(taskId, req);
+        return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, null));
+    }
+
+    // 업무 삭제(soft delete)
+    @DeleteMapping("/tasks/{taskId}")
+    public ResponseEntity<ApiResponse<Void>> deleteTask(
+            @PathVariable UUID taskId
+    ) {
+        taskService.deleteTask(taskId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(GeneralSuccessCode._OK, null));
+    }
 }

--- a/src/main/java/com/connecteamed/server/domain/task/controller/TaskController.java
+++ b/src/main/java/com/connecteamed/server/domain/task/controller/TaskController.java
@@ -48,7 +48,7 @@ public class TaskController {
     @Operation(summary = "업무 상세 조회", description = "업무 상세 조회 API입니다.")
     @GetMapping("/tasks/{taskId}/detail")
     public ResponseEntity<ApiResponse<TaskDetailRes>> getTaskDetail(
-            @PathVariable UUID taskId
+            @PathVariable Long taskId
     ) {
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(GeneralSuccessCode._OK, taskService.getTaskDetail(taskId))
@@ -69,7 +69,7 @@ public class TaskController {
     @Operation(summary = "업무 일정 수정(시작/마감)", description = "업무 일정 수정(시작/마감) API입니다.")
     @PatchMapping("/tasks/{taskId}/schedule")
     public ResponseEntity<ApiResponse<Void>> updateTaskSchedule(
-            @PathVariable UUID taskId,
+            @PathVariable Long taskId,
             @RequestBody @Valid TaskScheduleUpdateReq req
     ) {
         taskService.updateTaskSchedule(taskId, req);
@@ -79,7 +79,7 @@ public class TaskController {
     @Operation(summary = "담당자 변경(전체 교체)", description = "담당자 변경(전체 교체) API입니다.")
     @PatchMapping("/tasks/{taskId}/assignees")
     public ResponseEntity<ApiResponse<Void>> updateTaskAssignees(
-            @PathVariable UUID taskId,
+            @PathVariable Long taskId,
             @RequestBody @Valid TaskAssigneeUpdateReq req
     ) {
         taskService.updateTaskAssignees(taskId, req);

--- a/src/main/java/com/connecteamed/server/domain/task/dto/TaskAssigneeRes.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/TaskAssigneeRes.java
@@ -1,0 +1,11 @@
+package com.connecteamed.server.domain.task.dto;
+
+import java.util.UUID;
+
+public record TaskAssigneeRes(
+        Long projectMemberId,
+        Long memberId,
+        UUID memberPublicId,
+        String memberName
+) {
+}

--- a/src/main/java/com/connecteamed/server/domain/task/dto/TaskAssigneeUpdateReq.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/TaskAssigneeUpdateReq.java
@@ -1,0 +1,10 @@
+package com.connecteamed.server.domain.task.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record TaskAssigneeUpdateReq(
+        @NotNull List<Long> assigneeProjectMemberIds
+) {
+}

--- a/src/main/java/com/connecteamed/server/domain/task/dto/TaskAssigneeUpdateReq.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/TaskAssigneeUpdateReq.java
@@ -5,6 +5,6 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record TaskAssigneeUpdateReq(
-        @NotNull List<Long> assigneeProjectMemberIds
+        List<Long> assigneeProjectMemberIds
 ) {
 }

--- a/src/main/java/com/connecteamed/server/domain/task/dto/TaskCreateReq.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/TaskCreateReq.java
@@ -1,4 +1,16 @@
 package com.connecteamed.server.domain.task.dto;
 
-public class TaskCreateReq {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+import java.util.List;
+
+public record TaskCreateReq(
+        @NotBlank String name,
+        @NotBlank String content,
+        @NotNull Instant startDate,
+        @NotNull Instant dueDate,
+        List<Long> assigneeProjectMemberIds
+) {
 }

--- a/src/main/java/com/connecteamed/server/domain/task/dto/TaskScheduleUpdateReq.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/TaskScheduleUpdateReq.java
@@ -1,0 +1,11 @@
+package com.connecteamed.server.domain.task.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+
+public record TaskScheduleUpdateReq(
+        @NotNull Instant startDate,
+        @NotNull Instant dueDate
+) {
+}

--- a/src/main/java/com/connecteamed/server/domain/task/dto/TaskStatusUpdateReq.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/TaskStatusUpdateReq.java
@@ -1,0 +1,9 @@
+package com.connecteamed.server.domain.task.dto;
+
+import com.connecteamed.server.domain.task.enums.TaskStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record TaskStatusUpdateReq(
+        @NotNull TaskStatus status
+) {
+}

--- a/src/main/java/com/connecteamed/server/domain/task/dto/TaskSummaryRes.java
+++ b/src/main/java/com/connecteamed/server/domain/task/dto/TaskSummaryRes.java
@@ -6,16 +6,13 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
-public record TaskDetailRes(
+public record TaskSummaryRes(
         UUID taskId,
-        Long projectId,
         String name,
         String content,
         TaskStatus status,
         Instant startDate,
         Instant dueDate,
-        List<TaskAssigneeRes> assignees,
-        Instant createdAt,
-        Instant updatedAt
+        List<TaskAssigneeRes> assignees
 ) {
 }

--- a/src/main/java/com/connecteamed/server/domain/task/entity/Task.java
+++ b/src/main/java/com/connecteamed/server/domain/task/entity/Task.java
@@ -57,10 +57,6 @@ public class Task extends BaseEntity {
         this.content = content;
     }
 
-    public void softDelete() {
-        this.deletedAt = java.time.Instant.now();
-    }
-
     @PrePersist
     public void prePersist(){
         if(this.publicId == null){

--- a/src/main/java/com/connecteamed/server/domain/task/entity/Task.java
+++ b/src/main/java/com/connecteamed/server/domain/task/entity/Task.java
@@ -55,4 +55,17 @@ public class Task extends BaseEntity {
         }
     }
 
+    public void changeStatus(TaskStatus status) {
+        this.status = status;
+    }
+
+    public void changeSchedule(Instant startDate, Instant dueDate) {
+        this.startDate = startDate;
+        this.dueDate = dueDate;
+    }
+
+    public void softDelete() {
+        this.deletedAt = Instant.now();
+    }
+
 }

--- a/src/main/java/com/connecteamed/server/domain/task/exception/TaskErrorCode.java
+++ b/src/main/java/com/connecteamed/server/domain/task/exception/TaskErrorCode.java
@@ -1,0 +1,21 @@
+package com.connecteamed.server.domain.task.exception;
+
+import com.connecteamed.server.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TaskErrorCode implements BaseErrorCode {
+
+    TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "TASK404", "업무를 찾을 수 없습니다."),
+    PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT404", "프로젝트를 찾을 수 없습니다."),
+    INVALID_SCHEDULE(HttpStatus.BAD_REQUEST, "TASK400_1", "시작일은 마감일보다 늦을 수 없습니다."),
+    INVALID_ASSIGNEE(HttpStatus.BAD_REQUEST, "TASK400_2", "담당자 목록이 올바르지 않습니다."),
+    ASSIGNEE_NOT_IN_PROJECT(HttpStatus.BAD_REQUEST, "TASK400_3", "프로젝트에 속하지 않은 담당자가 포함되어 있습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/connecteamed/server/domain/task/exception/TaskException.java
+++ b/src/main/java/com/connecteamed/server/domain/task/exception/TaskException.java
@@ -1,0 +1,20 @@
+package com.connecteamed.server.domain.task.exception;
+
+import com.connecteamed.server.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class TaskException extends RuntimeException {
+
+    private final BaseErrorCode errorCode;
+
+    public TaskException(BaseErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public TaskException(BaseErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/connecteamed/server/domain/task/repository/TaskAssigneeRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/task/repository/TaskAssigneeRepository.java
@@ -1,0 +1,14 @@
+package com.connecteamed.server.domain.task.repository;
+
+import com.connecteamed.server.domain.task.entity.Task;
+import com.connecteamed.server.domain.task.entity.TaskAssignee;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TaskAssigneeRepository extends JpaRepository<TaskAssignee, Long> {
+
+    List<TaskAssignee> findAllByTask(Task task);
+
+    void deleteAllByTask(Task task);
+}

--- a/src/main/java/com/connecteamed/server/domain/task/repository/TaskAssigneeRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/task/repository/TaskAssigneeRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import com.connecteamed.server.domain.task.entity.Task;
 import com.connecteamed.server.domain.task.entity.TaskAssignee;
-//TODO: 정리하기
+
 public interface TaskAssigneeRepository extends JpaRepository<TaskAssignee, Long> {
 
     List<TaskAssignee> findAllByTask(Task task);

--- a/src/main/java/com/connecteamed/server/domain/task/repository/TaskAssigneeRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/task/repository/TaskAssigneeRepository.java
@@ -1,10 +1,13 @@
 package com.connecteamed.server.domain.task.repository;
 
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import com.connecteamed.server.domain.task.entity.Task;
 import com.connecteamed.server.domain.task.entity.TaskAssignee;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
 //TODO: 정리하기
 public interface TaskAssigneeRepository extends JpaRepository<TaskAssignee, Long> {
 
@@ -15,4 +18,10 @@ public interface TaskAssigneeRepository extends JpaRepository<TaskAssignee, Long
     List<TaskAssignee> findAllByTaskId(Long taskId);
 
     List<TaskAssignee> findAllByTaskIdIn(List<Long> taskIds);
+
+    @Query("SELECT ta FROM TaskAssignee ta " +
+        "JOIN FETCH ta.projectMember pm " +
+        "JOIN FETCH pm.member " +
+        "WHERE ta.task IN :tasks")
+    List<TaskAssignee> findAllByTaskInWithDetails(@Param("tasks") List<Task> tasks);
 }

--- a/src/main/java/com/connecteamed/server/domain/task/repository/TaskAssigneeRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/task/repository/TaskAssigneeRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.repository.query.Param;
 
 import com.connecteamed.server.domain.task.entity.Task;
@@ -13,7 +14,9 @@ public interface TaskAssigneeRepository extends JpaRepository<TaskAssignee, Long
 
     List<TaskAssignee> findAllByTask(Task task);
 
-    void deleteAllByTask(Task task);
+    @Modifying
+    @Query("DELETE FROM TaskAssignee ta WHERE ta.task = :task")
+    void deleteAllByTask(@Param("task") Task task);
   
     List<TaskAssignee> findAllByTaskId(Long taskId);
 

--- a/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
@@ -7,11 +7,12 @@ import com.connecteamed.server.domain.task.enums.TaskStatus;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-//TODO: 정리하기
+
 public interface TaskRepository extends JpaRepository<Task, Long> {
 
     Optional<Task> findByPublicIdAndDeletedAtIsNull(UUID publicId);
 
+    // TODO: 업무목록 조회 & 완료된 업무 목록 조회 -> 하나로 통일 필요
     List<Task> findAllByProject_IdAndDeletedAtIsNullOrderByStartDateAsc(Long projectId);
   
     List<Task> findAllByProjectIdAndStatusAndDeletedAtIsNull(Long projectId, TaskStatus status);

--- a/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
@@ -6,11 +6,10 @@ import com.connecteamed.server.domain.task.enums.TaskStatus;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
 
-    Optional<Task> findByPublicIdAndDeletedAtIsNull(UUID publicId);
+    Optional<Task> findByIdAndDeletedAtIsNull(Long id);
 
     // TODO: 업무목록 조회 & 완료된 업무 목록 조회 -> 하나로 통일 필요
     List<Task> findAllByProject_IdAndDeletedAtIsNullOrderByStartDateAsc(Long projectId);

--- a/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
@@ -1,4 +1,15 @@
 package com.connecteamed.server.domain.task.repository;
 
-public class TaskRepository {
+import com.connecteamed.server.domain.task.entity.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+
+    Optional<Task> findByPublicIdAndDeletedAtIsNull(UUID publicId);
+
+    List<Task> findAllByProject_IdAndDeletedAtIsNullOrderByStartDateAsc(Long projectId);
 }

--- a/src/main/java/com/connecteamed/server/domain/task/service/TaskService.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/TaskService.java
@@ -11,13 +11,13 @@ public interface TaskService {
 
     List<TaskSummaryRes> getProjectTasks(Long projectId);
 
-    TaskDetailRes getTaskDetail(UUID taskId);
+    TaskDetailRes getTaskDetail(Long taskId);
 
-    void updateTaskStatus(UUID taskId, TaskStatusUpdateReq req);
+    void updateTaskStatus(Long taskId, TaskStatusUpdateReq req);
 
-    void updateTaskSchedule(UUID taskId, TaskScheduleUpdateReq req);
+    void updateTaskSchedule(Long taskId, TaskScheduleUpdateReq req);
 
-    void updateTaskAssignees(UUID taskId, TaskAssigneeUpdateReq req);
+    void updateTaskAssignees(Long taskId, TaskAssigneeUpdateReq req);
 
-    void deleteTask(UUID taskId);
+    void deleteTask(Long taskId);
 }

--- a/src/main/java/com/connecteamed/server/domain/task/service/TaskService.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/TaskService.java
@@ -1,4 +1,23 @@
 package com.connecteamed.server.domain.task.service;
 
-public class TaskService {
+import com.connecteamed.server.domain.task.dto.*;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface TaskService {
+
+    UUID createTask(Long projectId, TaskCreateReq req);
+
+    List<TaskSummaryRes> getProjectTasks(Long projectId);
+
+    TaskDetailRes getTaskDetail(UUID taskId);
+
+    void updateTaskStatus(UUID taskId, TaskStatusUpdateReq req);
+
+    void updateTaskSchedule(UUID taskId, TaskScheduleUpdateReq req);
+
+    void updateTaskAssignees(UUID taskId, TaskAssigneeUpdateReq req);
+
+    void deleteTask(UUID taskId);
 }

--- a/src/main/java/com/connecteamed/server/domain/task/service/TaskServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/TaskServiceImpl.java
@@ -94,8 +94,8 @@ public class TaskServiceImpl implements TaskService {
 
     //업무 상세 조회
     @Override
-    public TaskDetailRes getTaskDetail(UUID taskId) {
-        Task task = taskRepository.findByPublicIdAndDeletedAtIsNull(taskId)
+    public TaskDetailRes getTaskDetail(Long taskId) {
+        Task task = taskRepository.findByIdAndDeletedAtIsNull(taskId)
                 .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND));
 
         List<TaskAssigneeRes> assignees = toAssigneeRes(taskAssigneeRepository.findAllByTask(task));
@@ -116,8 +116,8 @@ public class TaskServiceImpl implements TaskService {
 
     // 업무 상태 변경 TODO: Completed Task 겹침
     @Override
-    public void updateTaskStatus(UUID taskId, TaskStatusUpdateReq req) {
-        Task task = taskRepository.findByPublicIdAndDeletedAtIsNull(taskId)
+    public void updateTaskStatus(Long taskId, TaskStatusUpdateReq req) {
+        Task task = taskRepository.findByIdAndDeletedAtIsNull(taskId)
                 .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND));
 
         task.changeStatus(req.status());
@@ -125,8 +125,8 @@ public class TaskServiceImpl implements TaskService {
 
     // 업무 일정 수정
     @Override
-    public void updateTaskSchedule(UUID taskId, TaskScheduleUpdateReq req) {
-        Task task = taskRepository.findByPublicIdAndDeletedAtIsNull(taskId)
+    public void updateTaskSchedule(Long taskId, TaskScheduleUpdateReq req) {
+        Task task = taskRepository.findByIdAndDeletedAtIsNull(taskId)
                 .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND));
 
         if (req.startDate().isAfter(req.dueDate())) {
@@ -138,8 +138,8 @@ public class TaskServiceImpl implements TaskService {
 
     // 업무 담당자 변경
     @Override
-    public void updateTaskAssignees(UUID taskId, TaskAssigneeUpdateReq req) {
-        Task task = taskRepository.findByPublicIdAndDeletedAtIsNull(taskId)
+    public void updateTaskAssignees(Long taskId, TaskAssigneeUpdateReq req) {
+        Task task = taskRepository.findByIdAndDeletedAtIsNull(taskId)
                 .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND));
 
         Long projectId = task.getProject().getId();
@@ -152,8 +152,8 @@ public class TaskServiceImpl implements TaskService {
 
     // 업무 삭제 TODO: Completed Task 겹침 
     @Override
-    public void deleteTask(UUID taskId) {
-        Task task = taskRepository.findByPublicIdAndDeletedAtIsNull(taskId)
+    public void deleteTask(Long taskId) {
+        Task task = taskRepository.findByIdAndDeletedAtIsNull(taskId)
                 .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND));
 
         task.softDelete();

--- a/src/main/java/com/connecteamed/server/domain/task/service/TaskServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/TaskServiceImpl.java
@@ -72,7 +72,7 @@ public class TaskServiceImpl implements TaskService {
 
         // taskId(또는 task) 기준으로 grouping
         var assigneeMap = allAssignees.stream()
-                .collect(groupingBy(ta -> ta.getTask().getId()));
+                .collect(Collectors.groupingBy(ta -> ta.getTask().getId()));
 
         List<TaskSummaryRes> result = new ArrayList<>(tasks.size());
         for (Task task : tasks) {

--- a/src/main/java/com/connecteamed/server/domain/task/service/TaskServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/TaskServiceImpl.java
@@ -32,6 +32,7 @@ public class TaskServiceImpl implements TaskService {
     private final ProjectRepository projectRepository;
     private final ProjectMemberRepository projectMemberRepository;
 
+    //업무 추가
     @Override
     public UUID createTask(Long projectId, TaskCreateReq req) {
         Project project = projectRepository.findById(projectId)
@@ -57,6 +58,7 @@ public class TaskServiceImpl implements TaskService {
         return saved.getPublicId();
     }
 
+    //업무 목록 조회(전체)
     @Override
     public List<TaskSummaryRes> getProjectTasks(Long projectId) {
         projectRepository.findById(projectId)
@@ -90,6 +92,7 @@ public class TaskServiceImpl implements TaskService {
         return result;
     }
 
+    //업무 상세 조회
     @Override
     public TaskDetailRes getTaskDetail(UUID taskId) {
         Task task = taskRepository.findByPublicIdAndDeletedAtIsNull(taskId)
@@ -111,6 +114,7 @@ public class TaskServiceImpl implements TaskService {
         );
     }
 
+    // 업무 상태 변경 TODO: Completed Task 겹침
     @Override
     public void updateTaskStatus(UUID taskId, TaskStatusUpdateReq req) {
         Task task = taskRepository.findByPublicIdAndDeletedAtIsNull(taskId)
@@ -119,6 +123,7 @@ public class TaskServiceImpl implements TaskService {
         task.changeStatus(req.status());
     }
 
+    // 업무 일정 수정
     @Override
     public void updateTaskSchedule(UUID taskId, TaskScheduleUpdateReq req) {
         Task task = taskRepository.findByPublicIdAndDeletedAtIsNull(taskId)
@@ -131,6 +136,7 @@ public class TaskServiceImpl implements TaskService {
         task.changeSchedule(req.startDate(), req.dueDate());
     }
 
+    // 업무 담당자 변경
     @Override
     public void updateTaskAssignees(UUID taskId, TaskAssigneeUpdateReq req) {
         Task task = taskRepository.findByPublicIdAndDeletedAtIsNull(taskId)
@@ -144,6 +150,7 @@ public class TaskServiceImpl implements TaskService {
         attachAssignees(task, projectId, assigneeIds);
     }
 
+    // 업무 삭제 TODO: Completed Task 겹침 
     @Override
     public void deleteTask(UUID taskId) {
         Task task = taskRepository.findByPublicIdAndDeletedAtIsNull(taskId)

--- a/src/main/java/com/connecteamed/server/domain/task/service/TaskServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/TaskServiceImpl.java
@@ -1,0 +1,185 @@
+package com.connecteamed.server.domain.task.service;
+
+import com.connecteamed.server.domain.project.entity.Project;
+import com.connecteamed.server.domain.project.entity.ProjectMember;
+import com.connecteamed.server.domain.project.repository.ProjectMemberRepository;
+import com.connecteamed.server.domain.project.repository.ProjectRepository;
+import com.connecteamed.server.domain.task.dto.*;
+import com.connecteamed.server.domain.task.entity.Task;
+import com.connecteamed.server.domain.task.entity.TaskAssignee;
+import com.connecteamed.server.domain.task.exception.TaskErrorCode;
+import com.connecteamed.server.domain.task.exception.TaskException;
+import com.connecteamed.server.domain.task.repository.TaskAssigneeRepository;
+import com.connecteamed.server.domain.task.repository.TaskRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TaskServiceImpl implements TaskService {
+
+    private final TaskRepository taskRepository;
+    private final TaskAssigneeRepository taskAssigneeRepository;
+
+    private final ProjectRepository projectRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+
+    @Override
+    public UUID createTask(Long projectId, TaskCreateReq req) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new TaskException(TaskErrorCode.PROJECT_NOT_FOUND));
+
+        if (req.startDate().isAfter(req.dueDate())) {
+            throw new TaskException(TaskErrorCode.INVALID_SCHEDULE);
+        }
+
+        Task task = Task.builder()
+                .project(project)
+                .name(req.name())
+                .content(req.content())
+                .startDate(req.startDate())
+                .dueDate(req.dueDate())
+                .build();
+
+        Task saved = taskRepository.save(task);
+
+        List<Long> assigneeIds = req.assigneeProjectMemberIds() == null ? List.of() : req.assigneeProjectMemberIds();
+        attachAssignees(saved, projectId, assigneeIds);
+
+        return saved.getPublicId();
+    }
+
+    @Override
+    public List<TaskSummaryRes> getProjectTasks(Long projectId) {
+        projectRepository.findById(projectId)
+                .orElseThrow(() -> new TaskException(TaskErrorCode.PROJECT_NOT_FOUND));
+
+        List<Task> tasks = taskRepository.findAllByProject_IdAndDeletedAtIsNullOrderByStartDateAsc(projectId);
+
+        List<TaskSummaryRes> result = new ArrayList<>();
+        for (Task task : tasks) {
+            List<TaskAssigneeRes> assignees = toAssigneeRes(taskAssigneeRepository.findAllByTask(task));
+            result.add(new TaskSummaryRes(
+                    task.getPublicId(),
+                    task.getName(),
+                    task.getContent(),
+                    task.getStatus(),
+                    task.getStartDate(),
+                    task.getDueDate(),
+                    assignees
+            ));
+        }
+        return result;
+    }
+
+    @Override
+    public TaskDetailRes getTaskDetail(UUID taskId) {
+        Task task = taskRepository.findByPublicIdAndDeletedAtIsNull(taskId)
+                .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND));
+
+        List<TaskAssigneeRes> assignees = toAssigneeRes(taskAssigneeRepository.findAllByTask(task));
+
+        return new TaskDetailRes(
+                task.getPublicId(),
+                task.getProject().getId(),
+                task.getName(),
+                task.getContent(),
+                task.getStatus(),
+                task.getStartDate(),
+                task.getDueDate(),
+                assignees,
+                task.getCreatedAt(),
+                task.getUpdatedAt()
+        );
+    }
+
+    @Override
+    public void updateTaskStatus(UUID taskId, TaskStatusUpdateReq req) {
+        Task task = taskRepository.findByPublicIdAndDeletedAtIsNull(taskId)
+                .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND));
+
+        task.changeStatus(req.status());
+    }
+
+    @Override
+    public void updateTaskSchedule(UUID taskId, TaskScheduleUpdateReq req) {
+        Task task = taskRepository.findByPublicIdAndDeletedAtIsNull(taskId)
+                .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND));
+
+        if (req.startDate().isAfter(req.dueDate())) {
+            throw new TaskException(TaskErrorCode.INVALID_SCHEDULE);
+        }
+
+        task.changeSchedule(req.startDate(), req.dueDate());
+    }
+
+    @Override
+    public void updateTaskAssignees(UUID taskId, TaskAssigneeUpdateReq req) {
+        Task task = taskRepository.findByPublicIdAndDeletedAtIsNull(taskId)
+                .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND));
+
+        Long projectId = task.getProject().getId();
+
+        taskAssigneeRepository.deleteAllByTask(task);
+
+        List<Long> assigneeIds = req.assigneeProjectMemberIds() == null ? List.of() : req.assigneeProjectMemberIds();
+        attachAssignees(task, projectId, assigneeIds);
+    }
+
+    @Override
+    public void deleteTask(UUID taskId) {
+        Task task = taskRepository.findByPublicIdAndDeletedAtIsNull(taskId)
+                .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND));
+
+        task.softDelete();
+    }
+
+    private void attachAssignees(Task task, Long projectId, List<Long> projectMemberIds) {
+        if (projectMemberIds == null || projectMemberIds.isEmpty()) {
+            return;
+        }
+
+        List<Long> distinctIds = projectMemberIds.stream().distinct().toList();
+
+        List<ProjectMember> members = projectMemberRepository.findAllByIdIn(distinctIds);
+        if (members.size() != distinctIds.size()) {
+            throw new TaskException(TaskErrorCode.INVALID_ASSIGNEE);
+        }
+
+        for (ProjectMember pm : members) {
+            if (pm.getProject() == null || !Objects.equals(pm.getProject().getId(), projectId)) {
+                throw new TaskException(TaskErrorCode.ASSIGNEE_NOT_IN_PROJECT);
+            }
+        }
+
+        List<TaskAssignee> entities = members.stream()
+                .map(pm -> TaskAssignee.builder()
+                        .task(task)
+                        .projectMember(pm)
+                        .build()
+                )
+                .collect(Collectors.toList());
+
+        taskAssigneeRepository.saveAll(entities);
+    }
+
+    private List<TaskAssigneeRes> toAssigneeRes(List<TaskAssignee> assignees) {
+        List<TaskAssigneeRes> result = new ArrayList<>();
+        for (TaskAssignee ta : assignees) {
+            ProjectMember pm = ta.getProjectMember();
+
+            Long projectMemberId = pm.getId();
+            Long memberId = pm.getMember() != null ? pm.getMember().getId() : null;
+            UUID memberPublicId = pm.getMember() != null ? pm.getMember().getPublicId() : null;
+            String memberName = pm.getMember() != null ? pm.getMember().getName() : null;
+
+            result.add(new TaskAssigneeRes(projectMemberId, memberId, memberPublicId, memberName));
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/connecteamed/server/domain/task/service/TaskServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/TaskServiceImpl.java
@@ -72,7 +72,7 @@ public class TaskServiceImpl implements TaskService {
 
         // taskId(또는 task) 기준으로 grouping
         var assigneeMap = allAssignees.stream()
-                .collect(java.util.stream.Collectors.groupingBy(ta -> ta.getTask().getId()));
+                .collect(groupingBy(ta -> ta.getTask().getId()));
 
         List<TaskSummaryRes> result = new ArrayList<>(tasks.size());
         for (Task task : tasks) {

--- a/src/main/java/com/connecteamed/server/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/connecteamed/server/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import com.connecteamed.server.domain.task.exception.TaskException;
 import com.connecteamed.server.global.apiPayload.ApiResponse;
 import com.connecteamed.server.global.apiPayload.code.BaseErrorCode;
 import com.connecteamed.server.global.apiPayload.code.GeneralErrorCode;
@@ -107,6 +108,19 @@ public class GeneralExceptionAdvice {
         // 필요하면 그냥 404 응답만
         return ResponseEntity.status(404)
                 .body(ApiResponse.onFailure(GeneralErrorCode.NOT_FOUND, "리소스를 찾을 수 없습니다."));
+    }
+
+    @ExceptionHandler(TaskException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTaskException(TaskException e, HttpServletRequest req) {
+        log.warn("TaskException - {} {} - code={} msg={}",
+                req.getMethod(), req.getRequestURI(),
+                e.getErrorCode().getCode(),
+                e.getErrorCode().getMessage()
+        );
+
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ApiResponse.onFailure(e.getErrorCode()));
     }
 
     //사용자가 정의 하는 범위 외 발생 예외 처리- 실패응답 1 구조를 따름

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -25,12 +25,19 @@
       <a class="button" href="/member_role.html">팀원 목록 & 역할 테스트 페이지로 이동</a>
     </p>
 
+    <p>
+      <a class="button" href="/task.html">업무목록 테스트 페이지로 이동</a>
+    </p>
+
     <h3>바로가기</h3>
     <ul>
       <li><a href="/document.html">/document.html</a></li>
     </ul>
     <ul>
       <li><a href="/member_role.html">/member_role.html</a></li>
+    </ul>
+    <ul>
+      <li><a href="/task.html">/task.html</a></li>
     </ul>
   </div>
 </body>

--- a/src/main/resources/static/task.html
+++ b/src/main/resources/static/task.html
@@ -516,7 +516,7 @@
     const getTaskDetail = async () => {
       const taskId = getTaskId();
       if (!taskId) return alert("taskId를 입력하세요.");
-      const data = await api(`/api/tasks/${taskId}`, { method: "GET" });
+      const data = await api(`/api/tasks/${taskId}/detail`, { method: "GET" });
       log(data);
 
       // 상세에서 일정값을 채워줌(있으면)

--- a/src/main/resources/static/task.html
+++ b/src/main/resources/static/task.html
@@ -1,0 +1,530 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Task API 테스트</title>
+  <style>
+    :root{
+      --bg:#ffffff;
+      --card:#ffffff;
+      --line:#e5e7eb;
+      --text:#111827;
+      --muted:#6b7280;
+      --pill:#f3f4f6;
+      --pillText:#374151;
+    }
+    *{box-sizing:border-box}
+    body{
+      margin:0;
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      background:var(--bg);
+      color:var(--text);
+    }
+    .wrap{
+      max-width:1100px;
+      margin:18px auto;
+      padding:0 18px 40px;
+    }
+
+    /* card + table */
+    .card{
+      background:var(--card);
+      border:1px solid var(--line);
+      border-radius:12px;
+      overflow:hidden;
+      margin-top:14px;
+    }
+    table{
+      width:100%;
+      border-collapse:separate;
+      border-spacing:0;
+      font-size:14px;
+    }
+    thead th{
+      text-align:left;
+      font-weight:600;
+      color:#4b5563;
+      font-size:12px;
+      padding:14px 16px;
+      border-bottom:1px solid var(--line);
+      background:#fff;
+    }
+    tbody td{
+      padding:14px 16px;
+      border-bottom:1px solid var(--line);
+      vertical-align:middle;
+    }
+    tbody tr:last-child td{border-bottom:none}
+
+    .col-title{width:170px}
+    .col-content{width:auto}
+    .col-status{width:120px}
+    .col-date{width:120px}
+    .col-assignee{width:180px}
+    .col-actions{width:70px; text-align:right}
+
+    .muted{color:var(--muted); font-size:12px}
+    .ellipsis{
+      max-width:520px;
+      overflow:hidden;
+      text-overflow:ellipsis;
+      white-space:nowrap;
+    }
+
+    .pill{
+      display:inline-flex;
+      align-items:center;
+      padding:6px 10px;
+      border-radius:999px;
+      border:1px solid var(--line);
+      background:var(--pill);
+      color:var(--pillText);
+      font-size:12px;
+    }
+    .pill select{
+      border:none;
+      outline:none;
+      background:transparent;
+      font-size:12px;
+      color:var(--pillText);
+      cursor:pointer;
+      appearance:none;
+      padding-right:10px;
+    }
+
+    .btnDel{
+      border:none;
+      background:transparent;
+      color:#9ca3af;
+      cursor:pointer;
+      font-size:12px;
+    }
+    .btnDel:hover{color:#ef4444}
+
+    .footerBar{
+      display:flex;
+      justify-content:flex-end;
+      padding:14px 16px;
+      background:#fff;
+      border-top:1px solid var(--line);
+    }
+    .btnAdd{
+      background:#111827;
+      color:white;
+      border:none;
+      padding:10px 14px;
+      border-radius:10px;
+      cursor:pointer;
+      font-weight:700;
+      font-size:12px;
+    }
+
+    /* modal */
+    .overlay{
+      position:fixed;
+      inset:0;
+      background:rgba(0,0,0,.35);
+      display:none;
+      align-items:center;
+      justify-content:center;
+      padding:16px;
+      z-index:50;
+    }
+    .overlay.open{display:flex}
+    .modal{
+      width:min(720px, 100%);
+      background:#fff;
+      border-radius:14px;
+      border:1px solid var(--line);
+      overflow:hidden;
+    }
+    .modalHead{
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      padding:14px 16px;
+      border-bottom:1px solid var(--line);
+    }
+    .modalHead h3{
+      margin:0;
+      font-size:14px;
+      font-weight:800;
+    }
+    .modalClose{
+      border:none;
+      background:transparent;
+      font-size:18px;
+      cursor:pointer;
+      color:#6b7280;
+    }
+    .modalBody{padding:14px 16px}
+    .grid{
+      display:grid;
+      grid-template-columns: 1fr 1fr;
+      gap:12px;
+    }
+    .field{
+      display:flex;
+      flex-direction:column;
+      gap:6px;
+    }
+    label{
+      font-size:12px;
+      color:#6b7280;
+    }
+    input, textarea, select{
+      border:1px solid var(--line);
+      border-radius:10px;
+      padding:10px 12px;
+      font-size:14px;
+      outline:none;
+      background:#fff;
+    }
+    textarea{min-height:92px; resize:vertical}
+    .full{grid-column:1 / -1}
+    .modalFoot{
+      display:flex;
+      justify-content:flex-end;
+      gap:10px;
+      padding:12px 16px;
+      border-top:1px solid var(--line);
+      background:#fff;
+    }
+    .btn{
+      border:none;
+      border-radius:10px;
+      padding:10px 12px;
+      cursor:pointer;
+      font-weight:700;
+      font-size:13px;
+    }
+    .btn.secondary{
+      background:#f3f4f6;
+      color:#374151;
+    }
+    .btn.primary{
+      background:#111827;
+      color:#fff;
+    }
+
+    /* log (검정 배경 유지) */
+    .log{
+      margin-top:12px;
+      background:#0b1220;
+      color:#d1e7ff;
+      padding:12px 12px;
+      border-radius:12px;
+      overflow:auto;
+      font-size:12px;
+      line-height:1.45;
+      white-space:pre-wrap;
+      word-break:break-word;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+
+    <div class="card">
+      <table>
+        <thead>
+          <tr>
+            <th class="col-title">업무명</th>
+            <th class="col-content">업무내용</th>
+            <th class="col-status">상태</th>
+            <th class="col-date">시작일</th>
+            <th class="col-date">마감일</th>
+            <th class="col-assignee">담당자</th>
+            <th class="col-actions"></th>
+          </tr>
+        </thead>
+        <tbody id="tbody"></tbody>
+      </table>
+
+      <div class="footerBar">
+        <button class="btnAdd" id="btnOpenCreate">업무 추가</button>
+      </div>
+    </div>
+
+    <div class="log" id="log"></div>
+  </div>
+
+  <!-- Create Modal -->
+  <div class="overlay" id="overlay">
+    <div class="modal">
+      <div class="modalHead">
+        <h3>업무 추가</h3>
+        <button class="modalClose" id="btnClose">✕</button>
+      </div>
+      <div class="modalBody">
+        <div class="grid">
+          <div class="field">
+            <label>업무명</label>
+            <input id="cName" placeholder="예) API 명세서 작성" />
+          </div>
+
+          <div class="field">
+            <label>상태</label>
+            <select id="cStatus">
+              <option value="TODO">시작 전</option>
+              <option value="IN_PROGRESS">진행 중</option>
+              <option value="DONE">완료</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label>시작일</label>
+            <!-- date가 클릭 안 되는 경우가 있어서 text + showPicker로 처리 -->
+            <input id="cStart" type="date" />
+          </div>
+
+          <div class="field">
+            <label>마감일</label>
+            <input id="cDue" type="date" />
+          </div>
+
+          <div class="field full">
+            <label>업무내용</label>
+            <textarea id="cContent" placeholder="업무 설명을 적어주세요"></textarea>
+          </div>
+
+          <div class="field full">
+            <label>담당자 projectMemberId 목록 (쉼표로 구분)</label>
+            <input id="cAssignees" placeholder="예) 10,11,12" />
+          </div>
+        </div>
+      </div>
+      <div class="modalFoot">
+        <button class="btn secondary" id="btnCancel">취소</button>
+        <button class="btn primary" id="btnCreate">생성</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const $ = (id) => document.getElementById(id);
+
+    // 여기만 바꾸면 됩니다
+    const BASE_URL = "http://localhost:8080";
+    const PROJECT_ID = 1;
+
+    const toKDate = (isoOrInstant) => {
+      if (!isoOrInstant) return "-";
+      const d = new Date(isoOrInstant);
+      if (Number.isNaN(d.getTime())) return String(isoOrInstant).slice(0, 10);
+      const y = d.getFullYear();
+      const m = String(d.getMonth() + 1).padStart(2, "0");
+      const day = String(d.getDate()).padStart(2, "0");
+      return `${y}.${m}.${day}`;
+    };
+
+    const dateToInstantZulu = (yyyyMMdd) => {
+      return new Date(yyyyMMdd + "T00:00:00Z").toISOString();
+    };
+
+    const escapeHtml = (s) => {
+      return String(s ?? "")
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#039;");
+    };
+
+    const log = (obj) => {
+      const el = $("log");
+      const text = typeof obj === "string" ? obj : JSON.stringify(obj, null, 2);
+      el.textContent = text;
+    };
+
+    const api = async (path, opts = {}) => {
+      const url = BASE_URL.replace(/\/$/, "") + path;
+
+      const res = await fetch(url, {
+        headers: { "Content-Type": "application/json" },
+        ...opts
+      });
+
+      const text = await res.text();
+      let body = null;
+      try { body = text ? JSON.parse(text) : null; } catch (e) { body = text; }
+
+      if (!res.ok) throw { status: res.status, body };
+      return body;
+    };
+
+    const renderRows = (tasks) => {
+      const tbody = $("tbody");
+      tbody.innerHTML = "";
+
+      tasks.forEach(t => {
+        const tr = document.createElement("tr");
+
+        const assignees = (t.assignees || [])
+          .map(a => a.memberName || ("PM#" + a.projectMemberId))
+          .join(", ") || "-";
+
+        tr.innerHTML = `
+          <td class="col-title">
+            <div style="font-weight:700; font-size:13px;">${escapeHtml(t.name || "-")}</div>
+          </td>
+          <td class="col-content">
+            <div class="muted ellipsis">${escapeHtml(t.content || "")}</div>
+          </td>
+          <td class="col-status">
+            <span class="pill">
+              <select data-action="status" data-id="${t.taskId}">
+                <option value="TODO" ${t.status==="TODO"?"selected":""}>시작 전</option>
+                <option value="IN_PROGRESS" ${t.status==="IN_PROGRESS"?"selected":""}>진행 중</option>
+                <option value="DONE" ${t.status==="DONE"?"selected":""}>완료</option>
+              </select>
+            </span>
+          </td>
+          <td class="col-date">${toKDate(t.startDate)}</td>
+          <td class="col-date">${toKDate(t.dueDate)}</td>
+          <td class="col-assignee">
+            <span class="muted">${escapeHtml(assignees)}</span>
+          </td>
+          <td class="col-actions">
+            <button class="btnDel" data-action="delete" data-id="${t.taskId}">삭제</button>
+          </td>
+        `;
+        tbody.appendChild(tr);
+      });
+    };
+
+    const loadTasks = async () => {
+      const data = await api(`/api/projects/${PROJECT_ID}/tasks`, { method: "GET" });
+      if (data && data.status === "success") {
+        renderRows(data.data || []);
+      }
+      log(data);
+    };
+
+    const patchStatus = async (taskId, status) => {
+      const data = await api(`/api/tasks/${taskId}/status`, {
+        method: "PATCH",
+        body: JSON.stringify({ status })
+      });
+      log(data);
+    };
+
+    const deleteTask = async (taskId) => {
+      const data = await api(`/api/tasks/${taskId}`, { method: "DELETE" });
+      log(data);
+    };
+
+    const openModal = () => $("overlay").classList.add("open");
+    const closeModal = () => $("overlay").classList.remove("open");
+
+    const ensureDatePickerWorks = (inputEl) => {
+      // 일부 환경에서 date input 클릭이 막히는 경우(오버레이/레이아웃 이슈) 대비
+      // showPicker 지원 브라우저면 강제로 열어줌
+      inputEl.addEventListener("focus", () => {
+        if (typeof inputEl.showPicker === "function") {
+          try { inputEl.showPicker(); } catch (e) {}
+        }
+      });
+      inputEl.addEventListener("click", () => {
+        if (typeof inputEl.showPicker === "function") {
+          try { inputEl.showPicker(); } catch (e) {}
+        }
+      });
+    };
+
+    const createTask = async () => {
+      const name = $("cName").value.trim();
+      const content = $("cContent").value.trim();
+      const start = $("cStart").value;
+      const due = $("cDue").value;
+      const assigneesRaw = $("cAssignees").value.trim();
+
+      const assigneeProjectMemberIds = assigneesRaw
+        ? assigneesRaw.split(",").map(s => Number(s.trim())).filter(n => !Number.isNaN(n))
+        : [];
+
+      const payload = {
+        name,
+        content,
+        startDate: start ? dateToInstantZulu(start) : null,
+        dueDate: due ? dateToInstantZulu(due) : null,
+        assigneeProjectMemberIds
+      };
+
+      const data = await api(`/api/projects/${PROJECT_ID}/tasks`, {
+        method: "POST",
+        body: JSON.stringify(payload)
+      });
+
+      log(data);
+      await loadTasks();
+      closeModal();
+    };
+
+    // events
+    $("btnOpenCreate").addEventListener("click", () => {
+      // date 기본값
+      const today = new Date();
+      const yyyy = today.getFullYear();
+      const mm = String(today.getMonth()+1).padStart(2,"0");
+      const dd = String(today.getDate()).padStart(2,"0");
+      const t = `${yyyy}-${mm}-${dd}`;
+      if (!$("cStart").value) $("cStart").value = t;
+      if (!$("cDue").value) $("cDue").value = t;
+
+      openModal();
+      // 모달 열린 다음 date picker 강제 연결
+      ensureDatePickerWorks($("cStart"));
+      ensureDatePickerWorks($("cDue"));
+    });
+
+    $("btnClose").addEventListener("click", closeModal);
+    $("btnCancel").addEventListener("click", closeModal);
+    $("overlay").addEventListener("click", (e) => {
+      if (e.target === $("overlay")) closeModal();
+    });
+
+    $("btnCreate").addEventListener("click", async () => {
+      try {
+        await createTask();
+      } catch (e) {
+        log(e);
+        alert("생성 실패: 로그 확인");
+      }
+    });
+
+    $("tbody").addEventListener("change", async (e) => {
+      const target = e.target;
+      if (target && target.matches('select[data-action="status"]')) {
+        const taskId = target.getAttribute("data-id");
+        const status = target.value;
+        try {
+          await patchStatus(taskId, status);
+        } catch (err) {
+          log(err);
+          alert("상태 변경 실패: 로그 확인");
+        }
+      }
+    });
+
+    $("tbody").addEventListener("click", async (e) => {
+      const btn = e.target;
+      if (btn && btn.matches('button[data-action="delete"]')) {
+        const taskId = btn.getAttribute("data-id");
+        if (!confirm("삭제하시겠습니까?")) return;
+        try {
+          await deleteTask(taskId);
+          await loadTasks();
+        } catch (err) {
+          log(err);
+          alert("삭제 실패: 로그 확인");
+        }
+      }
+    });
+
+    // init
+    loadTasks().catch(err => log(err));
+  </script>
+</body>
+</html>

--- a/src/main/resources/static/task.html
+++ b/src/main/resources/static/task.html
@@ -549,7 +549,7 @@
         dueDate: dateToInstantZulu(due)
       };
 
-      const data = await api(`/api/tasks/${taskId}`, {
+      const data = await api(`/api/tasks/${taskId}/schedule`, {
         method: "PATCH",
         body: JSON.stringify(payload)
       });

--- a/src/main/resources/static/task.html
+++ b/src/main/resources/static/task.html
@@ -11,8 +11,19 @@
       --line:#e5e7eb;
       --text:#111827;
       --muted:#6b7280;
+
       --pill:#f3f4f6;
       --pillText:#374151;
+
+      --black:#0b1220;
+      --blueText:#d1e7ff;
+
+      --btn:#111827;
+      --btnText:#ffffff;
+      --btn2:#f3f4f6;
+      --btn2Text:#374151;
+
+      --danger:#ef4444;
     }
     *{box-sizing:border-box}
     body{
@@ -27,7 +38,29 @@
       padding:0 18px 40px;
     }
 
-    /* card + table */
+    /* tabs */
+    .tabs{
+      display:flex;
+      gap:22px;
+      align-items:center;
+      padding:14px 6px;
+      border-bottom:1px solid var(--line);
+      color:#374151;
+      font-size:14px;
+      user-select:none;
+    }
+    .tab{
+      padding:10px 2px;
+      border-bottom:2px solid transparent;
+      cursor:pointer;
+      white-space:nowrap;
+    }
+    .tab.active{
+      color:#111827;
+      border-bottom-color:#111827;
+      font-weight:700;
+    }
+
     .card{
       background:var(--card);
       border:1px solid var(--line);
@@ -35,6 +68,8 @@
       overflow:hidden;
       margin-top:14px;
     }
+
+    /* table */
     table{
       width:100%;
       border-collapse:separate;
@@ -59,10 +94,10 @@
 
     .col-title{width:170px}
     .col-content{width:auto}
-    .col-status{width:120px}
+    .col-status{width:140px}
     .col-date{width:120px}
-    .col-assignee{width:180px}
-    .col-actions{width:70px; text-align:right}
+    .col-assignee{width:200px}
+    .col-actions{width:120px; text-align:right}
 
     .muted{color:var(--muted); font-size:12px}
     .ellipsis{
@@ -99,26 +134,76 @@
       color:#9ca3af;
       cursor:pointer;
       font-size:12px;
+      margin-left:10px;
     }
-    .btnDel:hover{color:#ef4444}
+    .btnDel:hover{color:var(--danger)}
+
+    .btnLink{
+      border:none;
+      background:transparent;
+      color:#6b7280;
+      cursor:pointer;
+      font-size:12px;
+      text-decoration:underline;
+    }
+    .btnLink:hover{color:#111827}
 
     .footerBar{
       display:flex;
       justify-content:flex-end;
+      gap:10px;
       padding:14px 16px;
       background:#fff;
       border-top:1px solid var(--line);
     }
-    .btnAdd{
-      background:#111827;
-      color:white;
+    .btn{
       border:none;
-      padding:10px 14px;
       border-radius:10px;
+      padding:10px 12px;
       cursor:pointer;
       font-weight:700;
       font-size:12px;
     }
+    .btn.primary{
+      background:var(--btn);
+      color:var(--btnText);
+    }
+    .btn.secondary{
+      background:var(--btn2);
+      color:var(--btn2Text);
+    }
+
+    /* forms */
+    .formRow{
+      display:flex;
+      gap:10px;
+      flex-wrap:wrap;
+      align-items:flex-end;
+      padding:14px 16px;
+      border-bottom:1px solid var(--line);
+      background:#fff;
+    }
+    .field{
+      display:flex;
+      flex-direction:column;
+      gap:6px;
+      min-width:220px;
+    }
+    label{
+      font-size:12px;
+      color:#6b7280;
+    }
+    input, textarea, select{
+      border:1px solid var(--line);
+      border-radius:10px;
+      padding:10px 12px;
+      font-size:14px;
+      outline:none;
+      background:#fff;
+    }
+    textarea{min-height:80px; resize:vertical}
+    .field.small{min-width:160px}
+    .field.wide{min-width:360px}
 
     /* modal */
     .overlay{
@@ -133,7 +218,7 @@
     }
     .overlay.open{display:flex}
     .modal{
-      width:min(720px, 100%);
+      width:min(860px, 100%);
       background:#fff;
       border-radius:14px;
       border:1px solid var(--line);
@@ -164,24 +249,6 @@
       grid-template-columns: 1fr 1fr;
       gap:12px;
     }
-    .field{
-      display:flex;
-      flex-direction:column;
-      gap:6px;
-    }
-    label{
-      font-size:12px;
-      color:#6b7280;
-    }
-    input, textarea, select{
-      border:1px solid var(--line);
-      border-radius:10px;
-      padding:10px 12px;
-      font-size:14px;
-      outline:none;
-      background:#fff;
-    }
-    textarea{min-height:92px; resize:vertical}
     .full{grid-column:1 / -1}
     .modalFoot{
       display:flex;
@@ -191,28 +258,12 @@
       border-top:1px solid var(--line);
       background:#fff;
     }
-    .btn{
-      border:none;
-      border-radius:10px;
-      padding:10px 12px;
-      cursor:pointer;
-      font-weight:700;
-      font-size:13px;
-    }
-    .btn.secondary{
-      background:#f3f4f6;
-      color:#374151;
-    }
-    .btn.primary{
-      background:#111827;
-      color:#fff;
-    }
 
-    /* log (검정 배경 유지) */
+    /* log */
     .log{
       margin-top:12px;
-      background:#0b1220;
-      color:#d1e7ff;
+      background:var(--black);
+      color:var(--blueText);
       padding:12px 12px;
       border-radius:12px;
       overflow:auto;
@@ -221,12 +272,48 @@
       white-space:pre-wrap;
       word-break:break-word;
     }
+
+    .hint{
+      padding:0 16px 14px;
+      font-size:12px;
+      color:#6b7280;
+      background:#fff;
+    }
   </style>
 </head>
 <body>
   <div class="wrap">
+    <div class="tabs">
+      <div class="tab active">업무목록</div>
+    </div>
 
     <div class="card">
+      <!-- 상단 설정 + 단건 테스트 -->
+      <div class="formRow">
+        <div class="field small">
+          <label>Base URL</label>
+          <input id="baseUrl" value="http://localhost:8080" />
+        </div>
+        <div class="field small">
+          <label>projectId</label>
+          <input id="projectId" value="1" />
+        </div>
+        <div class="field wide">
+          <label>taskId (UUID)</label>
+          <input id="taskId" placeholder="예) 2d9b0a5b-...." />
+        </div>
+
+        <button class="btn secondary" id="btnList">목록 GET</button>
+        <button class="btn secondary" id="btnDetail">상세 GET</button>
+        <button class="btn secondary" id="btnDeleteOne">삭제 DELETE</button>
+      </div>
+
+      <div class="hint">
+        목록에서 행 클릭하면 taskId가 자동으로 채워집니다. 상태 변경은 드롭다운으로 PATCH /status 호출합니다.
+        일정 변경(PATCH /tasks/{taskId})과 담당자 변경(PATCH /assignees)은 아래 "단건 수정"에서 실행할 수 있습니다.
+      </div>
+
+      <!-- 테이블 -->
       <table>
         <thead>
           <tr>
@@ -243,7 +330,30 @@
       </table>
 
       <div class="footerBar">
-        <button class="btnAdd" id="btnOpenCreate">업무 추가</button>
+        <button class="btn primary" id="btnOpenCreate">업무 추가 POST</button>
+      </div>
+    </div>
+
+    <!-- 단건 수정 카드 -->
+    <div class="card" style="margin-top:14px;">
+      <div class="formRow">
+        <div class="field">
+          <label>일정 변경 (PATCH /api/tasks/{taskId}) - startDate</label>
+          <input id="uStart" type="date" />
+        </div>
+        <div class="field">
+          <label>일정 변경 (PATCH /api/tasks/{taskId}) - dueDate</label>
+          <input id="uDue" type="date" />
+        </div>
+        <button class="btn secondary" id="btnPatchSchedule">일정 PATCH</button>
+      </div>
+
+      <div class="formRow" style="border-bottom:none;">
+        <div class="field wide">
+          <label>담당자 변경 (PATCH /api/tasks/{taskId}/assignees) - projectMemberIds</label>
+          <input id="uAssignees" placeholder="예) 10,11,12" />
+        </div>
+        <button class="btn secondary" id="btnPatchAssignees">담당자 PATCH</button>
       </div>
     </div>
 
@@ -265,9 +375,9 @@
           </div>
 
           <div class="field">
-            <label>상태</label>
-            <select id="cStatus">
-              <option value="TODO">시작 전</option>
+            <label>상태 (참고용: 생성은 TODO로 시작해도 됩니다)</label>
+            <select id="cStatus" disabled>
+              <option value="TODO" selected>시작 전</option>
               <option value="IN_PROGRESS">진행 중</option>
               <option value="DONE">완료</option>
             </select>
@@ -275,7 +385,6 @@
 
           <div class="field">
             <label>시작일</label>
-            <!-- date가 클릭 안 되는 경우가 있어서 text + showPicker로 처리 -->
             <input id="cStart" type="date" />
           </div>
 
@@ -297,17 +406,13 @@
       </div>
       <div class="modalFoot">
         <button class="btn secondary" id="btnCancel">취소</button>
-        <button class="btn primary" id="btnCreate">생성</button>
+        <button class="btn primary" id="btnCreate">생성 POST</button>
       </div>
     </div>
   </div>
 
   <script>
     const $ = (id) => document.getElementById(id);
-
-    // 여기만 바꾸면 됩니다
-    const BASE_URL = "http://localhost:8080";
-    const PROJECT_ID = 1;
 
     const toKDate = (isoOrInstant) => {
       if (!isoOrInstant) return "-";
@@ -339,7 +444,8 @@
     };
 
     const api = async (path, opts = {}) => {
-      const url = BASE_URL.replace(/\/$/, "") + path;
+      const baseUrl = $("baseUrl").value.trim().replace(/\/$/, "");
+      const url = baseUrl + path;
 
       const res = await fetch(url, {
         headers: { "Content-Type": "application/json" },
@@ -387,19 +493,39 @@
             <span class="muted">${escapeHtml(assignees)}</span>
           </td>
           <td class="col-actions">
+            <button class="btnLink" data-action="pick" data-id="${t.taskId}">선택</button>
             <button class="btnDel" data-action="delete" data-id="${t.taskId}">삭제</button>
           </td>
         `;
+
         tbody.appendChild(tr);
       });
     };
 
+    const getProjectId = () => $("projectId").value.trim();
+    const getTaskId = () => $("taskId").value.trim();
+
     const loadTasks = async () => {
-      const data = await api(`/api/projects/${PROJECT_ID}/tasks`, { method: "GET" });
+      const data = await api(`/api/projects/${getProjectId()}/tasks`, { method: "GET" });
       if (data && data.status === "success") {
         renderRows(data.data || []);
       }
       log(data);
+    };
+
+    const getTaskDetail = async () => {
+      const taskId = getTaskId();
+      if (!taskId) return alert("taskId를 입력하세요.");
+      const data = await api(`/api/tasks/${taskId}`, { method: "GET" });
+      log(data);
+
+      // 상세에서 일정값을 채워줌(있으면)
+      if (data && data.status === "success" && data.data) {
+        const sd = data.data.startDate ? String(data.data.startDate).slice(0,10) : "";
+        const dd = data.data.dueDate ? String(data.data.dueDate).slice(0,10) : "";
+        if (sd) $("uStart").value = sd;
+        if (dd) $("uDue").value = dd;
+      }
     };
 
     const patchStatus = async (taskId, status) => {
@@ -410,17 +536,86 @@
       log(data);
     };
 
+    const patchSchedule = async () => {
+      const taskId = getTaskId();
+      if (!taskId) return alert("taskId를 입력하세요.");
+
+      const start = $("uStart").value;
+      const due = $("uDue").value;
+      if (!start || !due) return alert("startDate / dueDate를 모두 입력하세요.");
+
+      const payload = {
+        startDate: dateToInstantZulu(start),
+        dueDate: dateToInstantZulu(due)
+      };
+
+      const data = await api(`/api/tasks/${taskId}`, {
+        method: "PATCH",
+        body: JSON.stringify(payload)
+      });
+      log(data);
+      await loadTasks();
+    };
+
+    const patchAssignees = async () => {
+      const taskId = getTaskId();
+      if (!taskId) return alert("taskId를 입력하세요.");
+
+      const raw = $("uAssignees").value.trim();
+      const ids = raw
+        ? raw.split(",").map(s => Number(s.trim())).filter(n => !Number.isNaN(n))
+        : [];
+
+      const data = await api(`/api/tasks/${taskId}/assignees`, {
+        method: "PATCH",
+        body: JSON.stringify({ assigneeProjectMemberIds: ids })
+      });
+      log(data);
+      await loadTasks();
+    };
+
     const deleteTask = async (taskId) => {
       const data = await api(`/api/tasks/${taskId}`, { method: "DELETE" });
       log(data);
+      await loadTasks();
+    };
+
+    const createTask = async () => {
+      const name = $("cName").value.trim();
+      const content = $("cContent").value.trim();
+      const start = $("cStart").value;
+      const due = $("cDue").value;
+      const assigneesRaw = $("cAssignees").value.trim();
+
+      if (!name || !content) return alert("업무명/업무내용을 입력하세요.");
+      if (!start || !due) return alert("시작일/마감일을 입력하세요.");
+
+      const assigneeProjectMemberIds = assigneesRaw
+        ? assigneesRaw.split(",").map(s => Number(s.trim())).filter(n => !Number.isNaN(n))
+        : [];
+
+      const payload = {
+        name,
+        content,
+        startDate: dateToInstantZulu(start),
+        dueDate: dateToInstantZulu(due),
+        assigneeProjectMemberIds
+      };
+
+      const data = await api(`/api/projects/${getProjectId()}/tasks`, {
+        method: "POST",
+        body: JSON.stringify(payload)
+      });
+
+      log(data);
+      await loadTasks();
+      closeModal();
     };
 
     const openModal = () => $("overlay").classList.add("open");
     const closeModal = () => $("overlay").classList.remove("open");
 
     const ensureDatePickerWorks = (inputEl) => {
-      // 일부 환경에서 date input 클릭이 막히는 경우(오버레이/레이아웃 이슈) 대비
-      // showPicker 지원 브라우저면 강제로 열어줌
       inputEl.addEventListener("focus", () => {
         if (typeof inputEl.showPicker === "function") {
           try { inputEl.showPicker(); } catch (e) {}
@@ -433,38 +628,21 @@
       });
     };
 
-    const createTask = async () => {
-      const name = $("cName").value.trim();
-      const content = $("cContent").value.trim();
-      const start = $("cStart").value;
-      const due = $("cDue").value;
-      const assigneesRaw = $("cAssignees").value.trim();
+    // ---- events ----
+    $("btnList").addEventListener("click", () => loadTasks().catch(err => log(err)));
+    $("btnDetail").addEventListener("click", () => getTaskDetail().catch(err => log(err)));
 
-      const assigneeProjectMemberIds = assigneesRaw
-        ? assigneesRaw.split(",").map(s => Number(s.trim())).filter(n => !Number.isNaN(n))
-        : [];
+    $("btnDeleteOne").addEventListener("click", async () => {
+      const taskId = getTaskId();
+      if (!taskId) return alert("taskId를 입력하세요.");
+      if (!confirm("삭제하시겠습니까?")) return;
+      try { await deleteTask(taskId); } catch (e) { log(e); }
+    });
 
-      const payload = {
-        name,
-        content,
-        startDate: start ? dateToInstantZulu(start) : null,
-        dueDate: due ? dateToInstantZulu(due) : null,
-        assigneeProjectMemberIds
-      };
+    $("btnPatchSchedule").addEventListener("click", () => patchSchedule().catch(err => log(err)));
+    $("btnPatchAssignees").addEventListener("click", () => patchAssignees().catch(err => log(err)));
 
-      const data = await api(`/api/projects/${PROJECT_ID}/tasks`, {
-        method: "POST",
-        body: JSON.stringify(payload)
-      });
-
-      log(data);
-      await loadTasks();
-      closeModal();
-    };
-
-    // events
     $("btnOpenCreate").addEventListener("click", () => {
-      // date 기본값
       const today = new Date();
       const yyyy = today.getFullYear();
       const mm = String(today.getMonth()+1).padStart(2,"0");
@@ -474,7 +652,6 @@
       if (!$("cDue").value) $("cDue").value = t;
 
       openModal();
-      // 모달 열린 다음 date picker 강제 연결
       ensureDatePickerWorks($("cStart"));
       ensureDatePickerWorks($("cDue"));
     });
@@ -485,14 +662,7 @@
       if (e.target === $("overlay")) closeModal();
     });
 
-    $("btnCreate").addEventListener("click", async () => {
-      try {
-        await createTask();
-      } catch (e) {
-        log(e);
-        alert("생성 실패: 로그 확인");
-      }
-    });
+    $("btnCreate").addEventListener("click", () => createTask().catch(err => log(err)));
 
     $("tbody").addEventListener("change", async (e) => {
       const target = e.target;
@@ -509,19 +679,28 @@
     });
 
     $("tbody").addEventListener("click", async (e) => {
-      const btn = e.target;
-      if (btn && btn.matches('button[data-action="delete"]')) {
-        const taskId = btn.getAttribute("data-id");
+      const el = e.target;
+      if (!el) return;
+
+      if (el.matches('button[data-action="pick"]')) {
+        const taskId = el.getAttribute("data-id");
+        $("taskId").value = taskId;
+        // 단건 상세도 같이 불러와서 일정 입력칸 채우기
+        try { await getTaskDetail(); } catch (err) { log(err); }
+        return;
+      }
+
+      if (el.matches('button[data-action="delete"]')) {
+        const taskId = el.getAttribute("data-id");
         if (!confirm("삭제하시겠습니까?")) return;
-        try {
-          await deleteTask(taskId);
-          await loadTasks();
-        } catch (err) {
-          log(err);
-          alert("삭제 실패: 로그 확인");
-        }
+        try { await deleteTask(taskId); } catch (err) { log(err); }
+        return;
       }
     });
+
+    // date pickers (단건 수정 영역도 클릭 잘 되게)
+    ensureDatePickerWorks($("uStart"));
+    ensureDatePickerWorks($("uDue"));
 
     // init
     loadTasks().catch(err => log(err));


### PR DESCRIPTION
## 📌 PR 요약
- 업무(Task) API 구현 및 담당자(TaskAssignee) 연동 기능 추가

## 🔧 변경 사항
- 프로젝트 단위 업무 목록/생성/조회/수정/삭제까지 Task 도메인 API를 추가했습니다.
- 업무 담당자(프로젝트 멤버) 매핑을 위한 TaskAssignee 엔티티/저장 로직을 구현해, 업무에 여러 담당자를 할당/교체할 수 있도록 했습니다.
- 공통 응답(ApiResponse) 포맷에 맞춰 성공/실패 응답을 일관되게 반환하도록 구성했습니다.

## 📋 작업 상세 내용
- [x] Task 엔티티 및 TaskStatus enum 추가 (publicId 기반 식별, soft delete(deletedAt) 포함)
- [x] TaskAssignee 엔티티 추가 및 (task_id, project_member_id) 유니크 제약 기반 중복 할당 방지
- [x] Task Controller/Service/Repository 구현
- [x] ProjectMemberRepository 활용 검증 로직 반영

## 🔗 관련 이슈
- closed #16 

## 📝 기타
- API에서 taskId는 UUID(publicId) 기준으로 처리합니다.
- 담당자 변경/검증은 ProjectMemberRepository 기반으로 프로젝트 소속 여부를 확인합니다.
