### PR TITLE
[Feat] dashboard API

### DIFF
--- a/src/main/java/com/connecteamed/server/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/controller/DashboardController.java
@@ -105,7 +105,7 @@ public class DashboardController {
     @Operation(summary = "날짜별 업무 조회", description = "특정 날짜의 업무 및 일정을 조회합니다.")
     public ApiResponse<DailyScheduleListRes> getDailySchedules(
             @Parameter(description = "조회 날짜", example = "2026-01-22T00:00:00Z")
-            @RequestParam("data") Instant date,
+            @RequestParam("date") Instant date,
             Authentication authentication,
             @RequestParam(required = false) String username
     ) {

--- a/src/main/java/com/connecteamed/server/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/controller/DashboardController.java
@@ -1,6 +1,9 @@
 package com.connecteamed.server.domain.dashboard.controller;
 
+import com.connecteamed.server.domain.dashboard.dto.DailyScheduleListRes;
 import com.connecteamed.server.domain.dashboard.dto.DashboardRes;
+import com.connecteamed.server.domain.dashboard.dto.NotificationListRes;
+import com.connecteamed.server.domain.dashboard.dto.UpcomingTaskListRes;
 import com.connecteamed.server.domain.dashboard.service.DashboardService;
 import com.connecteamed.server.global.apiPayload.ApiResponse;
 import com.connecteamed.server.global.apiPayload.code.GeneralSuccessCode;
@@ -17,8 +20,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.Instant;
+
 @RestController
-@RequestMapping("/api/retrospectives")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 @Tag(name = "Dashboard", description = "대시보드 관련 API")
 public class DashboardController {
@@ -32,7 +37,7 @@ public class DashboardController {
      * @param username 개발 환경 테스트용 사용자 ID (선택)
      * @return 회고 목록 응답
      */
-    @GetMapping("/recent")
+    @GetMapping("/retrospectives/recent")
     @Operation(
             summary = "최근 회고 목록 조회",
             description = "로그인한 사용자가 작성한 최근 회고 목록을 조회합니다. 개발 환경에서는 username 파라미터로 테스트 가능합니다."
@@ -50,7 +55,7 @@ public class DashboardController {
             @RequestParam(required = false) String username
     ) {
         // 1. 인증된 사용자의 userId 추출 (JWT 토큰 또는 테스트 환경)
-        String userId = (authentication != null && authentication.isAuthenticated() 
+        String userId = (authentication != null && authentication.isAuthenticated()
                         && !"anonymousUser".equals(authentication.getName()))
                         ? authentication.getName()
                         : username;
@@ -69,6 +74,50 @@ public class DashboardController {
                 response,
                 "회고 목록 조회에 성공했습니다"
         );
+    }
+
+    @GetMapping("/tasks/upcoming")
+    @Operation(
+            summary = "다가오는 업무 조회",
+            description = "로그인한 사용자의 마감 임박 업무를 조회합니다."
+    )
+    public ApiResponse<UpcomingTaskListRes> getUpcomingTasks(
+            Authentication authentication,
+            @RequestParam(required = false) String username
+    ) {
+        String userId = getUserId(authentication, username);
+        UpcomingTaskListRes response = dashboardService.getUpcomingTasks(userId);
+        return ApiResponse.onSuccess(GeneralSuccessCode._OK, response, "다가오는 업무 조회에 성공했습니다");
+    }
+
+    @GetMapping("/notifications/recent")
+    @Operation(summary = "알림 조회", description = "로그인한 사용자의 최근 알림 목록을 조회합니다.")
+    public ApiResponse<NotificationListRes> getRecentNotifications(
+            Authentication authentication,
+            @RequestParam(required = false) String username
+    ) {
+        String userId = getUserId(authentication, username);
+        NotificationListRes response = dashboardService.getRecentNotifications(userId);
+        return ApiResponse.onSuccess(GeneralSuccessCode._OK, response, "알림 목록 조회에 성공했습니다");
+    }
+
+    @GetMapping("/schedules/daily")
+    @Operation(summary = "날짜별 업무 조회", description = "특정 날짜의 업무 및 일정을 조회합니다.")
+    public ApiResponse<DailyScheduleListRes> getDailySchedules(
+            @Parameter(description = "조회 날짜", example = "2026-01-22T00:00:00Z")
+            @RequestParam("data") Instant date,
+            Authentication authentication,
+            @RequestParam(required = false) String username
+    ) {
+        String userId = getUserId(authentication, username);
+        DailyScheduleListRes response = dashboardService.getDailySchedules(userId, date);
+        return ApiResponse.onSuccess(GeneralSuccessCode._OK, response, "날짜별 업무 조회에 성공했습니다");
+    }
+
+    private String getUserId(Authentication authentication, String username) {
+        return (authentication != null && authentication.isAuthenticated()
+                && !"anonymousUser".equals(authentication.getName()))
+                ? authentication.getName() : username;
     }
 }
 

--- a/src/main/java/com/connecteamed/server/domain/dashboard/dto/DailyScheduleListRes.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/dto/DailyScheduleListRes.java
@@ -1,0 +1,16 @@
+package com.connecteamed.server.domain.dashboard.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record DailyScheduleListRes (
+        Instant date,
+        List<ScheduleRes> schedules
+) {
+    public record ScheduleRes (
+            Long id,
+            String title,
+            String teamName,
+            Instant time
+    ) {}
+}

--- a/src/main/java/com/connecteamed/server/domain/dashboard/dto/NotificationListRes.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/dto/NotificationListRes.java
@@ -1,0 +1,16 @@
+package com.connecteamed.server.domain.dashboard.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record NotificationListRes (
+        List<NotificationRes> notifications
+) {
+    public record NotificationRes (
+            Long id,
+            String message,
+            String teamName,
+            boolean isRead,
+            Instant createdAt
+    ) {}
+}

--- a/src/main/java/com/connecteamed/server/domain/dashboard/dto/RetrospectiveListRes.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/dto/RetrospectiveListRes.java
@@ -1,0 +1,15 @@
+package com.connecteamed.server.domain.dashboard.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record RetrospectiveListRes (
+        List<RetrospectiveRes> retrospectives
+) {
+    public record RetrospectiveRes (
+            Long id,
+            String title,
+            String teamName,
+            Instant writtenDate
+    ) {}
+}

--- a/src/main/java/com/connecteamed/server/domain/dashboard/dto/UpcomingTaskListRes.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/dto/UpcomingTaskListRes.java
@@ -1,5 +1,6 @@
 package com.connecteamed.server.domain.dashboard.dto;
 
+import java.time.Instant;
 import java.util.List;
 
 public record UpcomingTaskListRes (
@@ -10,6 +11,6 @@ public record UpcomingTaskListRes (
             String status,
             String title,
             String teamName,
-            String dueDate
+            Instant dueDate
     ) {}
 }

--- a/src/main/java/com/connecteamed/server/domain/dashboard/dto/UpcomingTaskListRes.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/dto/UpcomingTaskListRes.java
@@ -8,9 +8,8 @@ public record UpcomingTaskListRes (
 ) {
     public record UpcomingTaskRes (
             Long id,
-            String status,
             String title,
             String teamName,
-            Instant dueDate
+            Instant writtenDate
     ) {}
 }

--- a/src/main/java/com/connecteamed/server/domain/dashboard/dto/UpcomingTaskListRes.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/dto/UpcomingTaskListRes.java
@@ -1,0 +1,15 @@
+package com.connecteamed.server.domain.dashboard.dto;
+
+import java.util.List;
+
+public record UpcomingTaskListRes (
+        List<UpcomingTaskRes> tasks
+) {
+    public record UpcomingTaskRes (
+            Long id,
+            String status,
+            String title,
+            String teamName,
+            String dueDate
+    ) {}
+}

--- a/src/main/java/com/connecteamed/server/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/service/DashboardService.java
@@ -63,7 +63,6 @@ public class DashboardService {
                         task.getProject().getName(),
                         task.getDueDate()
                 ))
-                .limit(5)
                 .toList();
 
         return new UpcomingTaskListRes(taskResList);
@@ -102,15 +101,15 @@ public class DashboardService {
                 t.getId(),
                 "[업무] " + t.getName(),
                 t.getProject().getName(),
-                t.getDueDate() // Instant 타입
+                t.getDueDate()
         )));
 
         // 회의 추가
         dailyMeetings.forEach(m -> resList.add(new DailyScheduleListRes.ScheduleRes(
                 m.getId(),
-                "[회의] " + m.getTitle(), // Meeting 엔티티 필드명 확인 (title 혹은 name)
+                "[회의] " + m.getTitle(),
                 m.getProject().getName(),
-                m.getMeetingDate() // Instant 타입
+                m.getMeetingDate()
         )));
 
         // 4. 시간순 정렬

--- a/src/main/java/com/connecteamed/server/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/service/DashboardService.java
@@ -58,7 +58,6 @@ public class DashboardService {
         List<UpcomingTaskListRes.UpcomingTaskRes> taskResList = tasks.stream()
                 .map(task -> new UpcomingTaskListRes.UpcomingTaskRes(
                         task.getId(),
-                        task.getStatus().name(),
                         task.getName(),
                         task.getProject().getName(),
                         task.getDueDate()

--- a/src/main/java/com/connecteamed/server/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/service/DashboardService.java
@@ -68,7 +68,7 @@ public class DashboardService {
     }
 
     public NotificationListRes getRecentNotifications(String userId) {
-        List<Notification> notifications = notificationRepository.findAllByReceiverRecordId(userId);
+        List<Notification> notifications = notificationRepository.findAllByReceiverLoginIdOrderByCreatedAtDesc(userId);
         List<NotificationListRes.NotificationRes> resList = notifications.stream()
                 .map(n -> new NotificationListRes.NotificationRes(
                         n.getId(),

--- a/src/main/java/com/connecteamed/server/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/entity/Meeting.java
@@ -1,6 +1,7 @@
 package com.connecteamed.server.domain.meeting.entity;
 
 import com.connecteamed.server.domain.project.entity.Project;
+import com.connecteamed.server.domain.project.entity.ProjectMember;
 import com.connecteamed.server.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -46,9 +47,17 @@ public class Meeting extends BaseEntity {
     @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MeetingAttendee> attendees = new ArrayList<>();
 
-    public void update(String title, java.time.Instant meetingDate) {
+    public void update(String title, Instant meetingDate) {
         this.title = title;
         this.meetingDate = meetingDate;
+    }
+
+    public void addAttendee(ProjectMember member) {
+        MeetingAttendee attendee = MeetingAttendee.builder()
+                .meeting(this)
+                .attendee(member)
+                .build();
+        this.attendees.add(attendee);
     }
 
     @PrePersist

--- a/src/main/java/com/connecteamed/server/domain/meeting/entity/MeetingAttendee.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/entity/MeetingAttendee.java
@@ -29,7 +29,8 @@ public class MeetingAttendee extends BaseEntity {
     @JoinColumn(name = "meeting_id", nullable = false)
     private Meeting meeting;
 
-    @Column(name = "attendee_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "attendee_id", nullable = false)
     private ProjectMember attendee;
 
 }

--- a/src/main/java/com/connecteamed/server/domain/meeting/entity/MeetingAttendee.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/entity/MeetingAttendee.java
@@ -15,7 +15,7 @@ import lombok.*;
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_meeting_attendee_meeting_member",
-                        columnNames = {"meeting_id", "attendee_id"} // 조합 unique 반영
+                        columnNames = {"meeting_id", "attendee_id"}
                 )
         }
 )
@@ -29,11 +29,7 @@ public class MeetingAttendee extends BaseEntity {
     @JoinColumn(name = "meeting_id", nullable = false)
     private Meeting meeting;
 
-    // 기존 ProjectMember 대신 Long 타입 ID 필드 추가
     @Column(name = "attendee_id", nullable = false)
-    private Long attendeeId;
+    private ProjectMember attendee;
 
-    //@ManyToOne(fetch = FetchType.LAZY)
-    //@JoinColumn(name = "attendee_id", nullable = false)
-    //private ProjectMember projectMember;
 }

--- a/src/main/java/com/connecteamed/server/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/repository/MeetingRepository.java
@@ -13,7 +13,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     List<Meeting> findAllByProjectIdAndDeletedAtIsNull(Long projectId);
     Optional<Meeting> findByIdAndDeletedAtIsNull(Long meetingId);
 
-    @Query("SELECT m FROM Meeting m " +
+    @Query("SELECT DISTINCT m FROM Meeting m " +
             "JOIN FETCH m.project p " +
             "JOIN m.attendees ma " +
             "JOIN ma.attendee pm " +

--- a/src/main/java/com/connecteamed/server/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/repository/MeetingRepository.java
@@ -15,8 +15,8 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
     @Query("SELECT m FROM Meeting m " +
             "JOIN FETCH m.project p " +
-            "JOIN MeetingAttendee ma ON ma.meeting = m " +
-            "JOIN ProjectMember pm ON pm.id = ma.attendeeId " +
+            "JOIN m.attendees ma " +
+            "JOIN ma.attendee pm " +
             "JOIN pm.member mem " +
             "WHERE mem.loginId = :userId " +
             "AND m.meetingDate >= :startOfDay AND m.meetingDate < :endOfDay " +

--- a/src/main/java/com/connecteamed/server/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/repository/MeetingRepository.java
@@ -14,9 +14,12 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     Optional<Meeting> findByIdAndDeletedAtIsNull(Long meetingId);
 
     @Query("SELECT m FROM Meeting m " +
-            "JOIN FETCH m.project " +
-            "WHERE m.receiver.recordId = :userId " + // 수신자 필드명 확인 필요
-            "AND m.startTime >= :startOfDay AND m.startTime < :endOfDay " +
+            "JOIN FETCH m.project p " +
+            "JOIN MeetingAttendee ma ON ma.meeting = m " +
+            "JOIN ProjectMember pm ON pm.id = ma.attendeeId " +
+            "JOIN pm.member mem " +
+            "WHERE mem.loginId = :userId " +
+            "AND m.meetingDate >= :startOfDay AND m.meetingDate < :endOfDay " +
             "AND m.deletedAt IS NULL")
     List<Meeting> findAllByMemberAndDate(
             @Param("userId") String userId,

--- a/src/main/java/com/connecteamed/server/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/repository/MeetingRepository.java
@@ -2,11 +2,25 @@ package com.connecteamed.server.domain.meeting.repository;
 
 import com.connecteamed.server.domain.meeting.entity.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     List<Meeting> findAllByProjectIdAndDeletedAtIsNull(Long projectId);
     Optional<Meeting> findByIdAndDeletedAtIsNull(Long meetingId);
+
+    @Query("SELECT m FROM Meeting m " +
+            "JOIN FETCH m.project " +
+            "WHERE m.receiver.recordId = :userId " + // 수신자 필드명 확인 필요
+            "AND m.startTime >= :startOfDay AND m.startTime < :endOfDay " +
+            "AND m.deletedAt IS NULL")
+    List<Meeting> findAllByMemberAndDate(
+            @Param("userId") String userId,
+            @Param("startOfDay") Instant startOfDay,
+            @Param("endOfDay") Instant endOfDay
+    );
 }

--- a/src/main/java/com/connecteamed/server/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/notification/repository/NotificationRepository.java
@@ -11,7 +11,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     @Query("SELECT n FROM Notification n " +
             "JOIN FETCH n.project " +
-            "WHERE n.receiver.recordId = :userId " +
+            "WHERE n.receiver.loginId = :userId " +
             "ORDER BY n.createdAt DESC")
     List<Notification> findAllByReceiverRecordId(@Param("userId") String userId);
 }

--- a/src/main/java/com/connecteamed/server/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/notification/repository/NotificationRepository.java
@@ -1,6 +1,7 @@
 package com.connecteamed.server.domain.notification.repository;
 
 import com.connecteamed.server.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,9 +10,6 @@ import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    @Query("SELECT n FROM Notification n " +
-            "JOIN FETCH n.project " +
-            "WHERE n.receiver.loginId = :userId " +
-            "ORDER BY n.createdAt DESC")
-    List<Notification> findAllByReceiverRecordId(@Param("userId") String userId);
+    @EntityGraph(attributePaths = {"project"})
+    List<Notification> findAllByReceiverLoginIdOrderByCreatedAtDesc(String loginId);
 }

--- a/src/main/java/com/connecteamed/server/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/notification/repository/NotificationRepository.java
@@ -1,4 +1,17 @@
 package com.connecteamed.server.domain.notification.repository;
 
-public class NotificationRepository {
+import com.connecteamed.server.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query("SELECT n FROM Notification n " +
+            "JOIN FETCH n.project " +
+            "WHERE n.receiver.recordId = :userId " +
+            "ORDER BY n.createdAt DESC")
+    List<Notification> findAllByReceiverRecordId(@Param("userId") String userId);
 }

--- a/src/main/java/com/connecteamed/server/domain/task/entity/Task.java
+++ b/src/main/java/com/connecteamed/server/domain/task/entity/Task.java
@@ -7,6 +7,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -27,6 +29,10 @@ public class Task extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="project_id",nullable = false)
     private Project project;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "task", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TaskAssignee> assignees = new ArrayList<>();
 
     @Column(name="name",nullable = false)
     private String name;

--- a/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
@@ -22,7 +22,7 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     @Query("SELECT t FROM Task t " +
             "JOIN FETCH t.project p " +
             "JOIN ProjectMember pm ON pm.project = p " +
-            "WHERE pm.member.recordId = :userId " +
+            "WHERE pm.member.loginId = :userId " +
             "AND t.status IN :statuses " +
             "AND t.deletedAt IS NULL " +
             "ORDER BY t.dueDate ASC")
@@ -32,9 +32,9 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     );
 
     @Query("SELECT t FROM Task t " +
-            "JOIN FETCH t.project " +
+            "JOIN FETCH t.project p " +
             "JOIN ProjectMember pm ON pm.project = p " +
-            "WHERE pm.member.recordId = :userId " +
+            "WHERE pm.member.loginId = :userId " +
             "AND t.dueDate >= :startOfDay AND t.dueDate < :endOfDay " +
             "AND t.deletedAt IS NULL")
     List<Task> findAllByMemberAndDate(

--- a/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
@@ -21,7 +21,7 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 
     @Query("SELECT t FROM Task t " +
             "JOIN FETCH t.project p " +
-            "JOIN p.projectMembers pm " +
+            "JOIN ProjectMember pm ON pm.project = p " +
             "WHERE pm.member.recordId = :userId " +
             "AND t.status IN :statuses " +
             "AND t.deletedAt IS NULL " +
@@ -33,7 +33,7 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 
     @Query("SELECT t FROM Task t " +
             "JOIN FETCH t.project " +
-            "JOIN p.projectMembers pm " +
+            "JOIN ProjectMember pm ON pm.project = p " +
             "WHERE pm.member.recordId = :userId " +
             "AND t.dueDate >= :startOfDay AND t.dueDate < :endOfDay " +
             "AND t.deletedAt IS NULL")

--- a/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
@@ -3,9 +3,37 @@ package com.connecteamed.server.domain.task.repository;
 import com.connecteamed.server.domain.task.entity.Task;
 import com.connecteamed.server.domain.task.enums.TaskStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.List;
 
 public interface TaskRepository extends JpaRepository<Task,Long> {
     List<Task> findAllByProjectIdAndStatusAndDeletedAtIsNull(Long projectId, TaskStatus status);
+
+    @Query("SELECT t FROM Task t " +
+            "JOIN FETCH t.project p " +
+            "JOIN p.projectMembers pm " +
+            "WHERE pm.member.recordId = :userId " +
+            "AND t.status IN :statuses " +
+            "AND t.deletedAt IS NULL " +
+            "ORDER BY t.dueDate ASC")
+    List<Task> findUpcomingTasksByUserId(
+            @Param("userId") String userId,
+            @Param("statuses") List<TaskStatus> statuses
+    );
+
+    @Query("SELECT t FROM Task t " +
+            "JOIN FETCH t.project " +
+            "JOIN p.projectMembers pm " +
+            "WHERE pm.member.recordId = :userId " +
+            "AND t.dueDate >= :startOfDay AND t.dueDate < :endOfDay " +
+            "AND t.deletedAt IS NULL")
+    List<Task> findAllByMemberAndDate(
+            @Param("userId") String userId,
+            @Param("startOfDay") Instant startOfDay,
+            @Param("endOfDay") Instant endOfDay
+    );
+
 }

--- a/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/task/repository/TaskRepository.java
@@ -19,10 +19,12 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
   
     List<Task> findAllByProjectIdAndStatusAndDeletedAtIsNull(Long projectId, TaskStatus status);
 
-    @Query("SELECT t FROM Task t " +
+    @Query("SELECT DISTINCT t FROM Task t " +
             "JOIN FETCH t.project p " +
-            "JOIN ProjectMember pm ON pm.project = p " +
-            "WHERE pm.member.loginId = :userId " +
+            "JOIN t.assignees ta " +
+            "JOIN ta.projectMember pm " +
+            "JOIN pm.member m " +
+            "WHERE m.loginId = :userId " +
             "AND t.status IN :statuses " +
             "AND t.deletedAt IS NULL " +
             "ORDER BY t.dueDate ASC")
@@ -31,10 +33,12 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
             @Param("statuses") List<TaskStatus> statuses
     );
 
-    @Query("SELECT t FROM Task t " +
+    @Query("SELECT DISTINCT t FROM Task t " +
             "JOIN FETCH t.project p " +
-            "JOIN ProjectMember pm ON pm.project = p " +
-            "WHERE pm.member.loginId = :userId " +
+            "JOIN t.assignees ta " +
+            "JOIN ta.projectMember pm " +
+            "JOIN pm.member m " +
+            "WHERE m.loginId = :userId " +
             "AND t.dueDate >= :startOfDay AND t.dueDate < :endOfDay " +
             "AND t.deletedAt IS NULL")
     List<Task> findAllByMemberAndDate(

--- a/src/test/java/com/connecteamed/server/domain/dashboard/service/DashboardServiceIntegrationTest.java
+++ b/src/test/java/com/connecteamed/server/domain/dashboard/service/DashboardServiceIntegrationTest.java
@@ -1,0 +1,164 @@
+package com.connecteamed.server.domain.dashboard.service;
+
+import com.connecteamed.server.domain.dashboard.dto.DailyScheduleListRes;
+import com.connecteamed.server.domain.dashboard.dto.NotificationListRes;
+import com.connecteamed.server.domain.dashboard.dto.UpcomingTaskListRes;
+import com.connecteamed.server.domain.member.entity.Member;
+import com.connecteamed.server.domain.member.enums.SocialType;
+import com.connecteamed.server.domain.member.repository.MemberRepository;
+import com.connecteamed.server.domain.meeting.entity.Meeting;
+import com.connecteamed.server.domain.meeting.repository.MeetingRepository;
+import com.connecteamed.server.domain.notification.entity.Notification;
+import com.connecteamed.server.domain.notification.entity.NotificationType;
+import com.connecteamed.server.domain.notification.repository.NotificationRepository;
+import com.connecteamed.server.domain.project.entity.Project;
+import com.connecteamed.server.domain.project.entity.ProjectMember;
+import com.connecteamed.server.domain.project.repository.ProjectMemberRepository;
+import com.connecteamed.server.domain.project.repository.ProjectRepository;
+import com.connecteamed.server.domain.task.entity.Task;
+import com.connecteamed.server.domain.task.entity.TaskAssignee;
+import com.connecteamed.server.domain.task.enums.TaskStatus;
+import com.connecteamed.server.domain.task.repository.TaskRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class DashboardServiceIntegrationTest {
+
+    @Autowired
+    private DashboardService dashboardService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private ProjectMemberRepository projectMemberRepository;
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Member testMember;
+    private Project testProject;
+    private ProjectMember testProjectMember;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 기본 데이터 저장
+        testMember = memberRepository.save(Member.builder()
+                .loginId("testUser")
+                .name("테스터")
+                .socialType(SocialType.LOCAL)
+                .build());
+
+        testProject = projectRepository.save(Project.builder()
+                .name("테스트 프로젝트")
+                .owner(testMember)
+                .goal("테스트 프로젝트 목표")
+                .build());
+
+        testProjectMember = projectMemberRepository.save(ProjectMember.builder()
+                .project(testProject)
+                .member(testMember)
+                .build());
+    }
+
+    @Test
+    @DisplayName("통합 테스트 1: 마감 임박 업무 조회 (TaskAssignee 연관관계 쿼리 검증)")
+    void getUpcomingTasks_Integration() {
+        // Given: 업무 생성 및 담당자 지정
+        Task task = taskRepository.save(Task.builder()
+                .project(testProject)
+                .name("마감 업무")
+                .content("내용")
+                .status(TaskStatus.TODO)
+                .startDate(Instant.now())
+                .dueDate(Instant.now().plus(1, ChronoUnit.DAYS))
+                .build());
+
+        // TaskAssignee를 통해 연관관계 맺기
+        task.getAssignees().add(TaskAssignee.builder()
+                .task(task)
+                .projectMember(testProjectMember)
+                .build());
+        taskRepository.save(task);
+
+        // When: 서비스 호출 (JPQL 실행)
+        UpcomingTaskListRes result = dashboardService.getUpcomingTasks(testMember.getLoginId());
+
+        // Then: 쿼리가 정상 작동하여 데이터를 가져오는지 검증
+        assertThat(result.tasks()).isNotEmpty();
+        assertThat(result.tasks().get(0).title()).isEqualTo("마감 업무");
+    }
+
+    @Test
+    @DisplayName("통합 테스트 2: 알림 목록 조회 (메서드 이름 쿼리 검증)")
+    void getRecentNotifications_Integration() {
+        // Given: 알림 타입 생성 및 em을 통해 직접 저장
+        NotificationType type = NotificationType.builder()
+                .typeKey("TASK_TAGGED")
+                .displayName("업무 태그 알림")
+                .build();
+        em.persist(type);
+
+        // Notification 저장
+        notificationRepository.save(Notification.builder()
+                .receiver(testMember)
+                .project(testProject)
+                .content("새로운 알림")
+                .targetUrl("/test")
+                .isRead(false)
+                .notificationType(type)
+                .build());
+
+        // When: 서비스 호출
+        NotificationListRes result = dashboardService.getRecentNotifications(testMember.getLoginId());
+
+        // Then: 검증
+        assertThat(result.notifications()).hasSize(1);
+        assertThat(result.notifications().get(0).message()).isEqualTo("새로운 알림");
+    }
+
+    @Test
+    @DisplayName("통합 테스트 3: 날짜별 일정 조회 (Meeting/Task JOIN FETCH 쿼리 검증)")
+    void getDailySchedules_Integration() {
+        // Given: 오늘 날짜의 회의 저장
+        Instant today = Instant.now();
+        Meeting meeting = Meeting.builder()
+                .project(testProject)
+                .title("중요 회의")
+                .meetingDate(today.plus(1, ChronoUnit.HOURS))
+                .build();
+        meeting.addAttendee(testProjectMember);
+        meetingRepository.save(meeting);
+
+        // When: 오늘 일정 조회
+        DailyScheduleListRes result = dashboardService.getDailySchedules(testMember.getLoginId(), today);
+
+        // Then: Meeting 연관관계(Attendees)를 통해 조회가 잘 되는지 검증
+        assertThat(result.schedules()).anyMatch(s -> s.title().contains("중요 회의"));
+    }
+}

--- a/src/test/java/com/connecteamed/server/domain/dashboard/service/DashboardServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/dashboard/service/DashboardServiceTest.java
@@ -88,7 +88,7 @@ public class DashboardServiceTest {
     void getRecentNotifications_Success() {
         Notification notification = Notification.builder()
                 .id(1L).content("새로운 메시지").project(testProject).isRead(false).build();
-        given(notificationRepository.findAllByReceiverRecordId(userId)).willReturn(List.of(notification));
+        given(notificationRepository.findAllByReceiverLoginIdOrderByCreatedAtDesc(userId)).willReturn(List.of(notification));
 
         NotificationListRes result = dashboardService.getRecentNotifications(userId);
 

--- a/src/test/java/com/connecteamed/server/domain/dashboard/service/DashboardServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/dashboard/service/DashboardServiceTest.java
@@ -1,0 +1,118 @@
+package com.connecteamed.server.domain.dashboard.service;
+
+import com.connecteamed.server.domain.dashboard.dto.DailyScheduleListRes;
+import com.connecteamed.server.domain.dashboard.dto.DashboardRes;
+import com.connecteamed.server.domain.dashboard.dto.NotificationListRes;
+import com.connecteamed.server.domain.dashboard.dto.UpcomingTaskListRes;
+import com.connecteamed.server.domain.meeting.entity.Meeting;
+import com.connecteamed.server.domain.meeting.repository.MeetingRepository;
+import com.connecteamed.server.domain.notification.entity.Notification;
+import com.connecteamed.server.domain.notification.repository.NotificationRepository;
+import com.connecteamed.server.domain.project.entity.Project;
+import com.connecteamed.server.domain.retrospective.entity.AiRetrospective;
+import com.connecteamed.server.domain.retrospective.repository.RetrospectiveRepository;
+import com.connecteamed.server.domain.task.entity.Task;
+import com.connecteamed.server.domain.task.enums.TaskStatus;
+import com.connecteamed.server.domain.task.repository.TaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class DashboardServiceTest {
+
+    @InjectMocks
+    private DashboardService dashboardService;
+
+    @Mock
+    private RetrospectiveRepository retrospectiveRepository;
+    @Mock
+    private TaskRepository taskRepository;
+    @Mock
+    private NotificationRepository notificationRepository;
+    @Mock
+    private MeetingRepository meetingRepository;
+
+    private Project testProject;
+    private final String userId = "testUser";
+
+    @BeforeEach
+    void setUp(){
+        testProject = Project.builder().name("테스트 프로젝트").build();
+    }
+
+    @Test
+    @DisplayName("1. 최근 회고 목록 조회 - 엔티티가 DTO로 정확히 변환된다.")
+    void getRecentRetrospectives_Success() {
+        AiRetrospective retro = AiRetrospective.builder()
+                .id(1L).title("회고 제목").project(testProject).build();
+
+        org.springframework.test.util.ReflectionTestUtils.setField(retro, "createdAt", java.time.Instant.now());
+        given(retrospectiveRepository.findRecentRetrospectives()).willReturn(List.of(retro));
+
+        DashboardRes.RetrospectiveListRes result = dashboardService.getRecentRetrospectives();
+
+        assertThat(result.getRetrospectives()).hasSize(1);
+        assertThat(result.getRetrospectives().get(0).getTitle()).isEqualTo("회고 제목");
+        assertThat(result.getRetrospectives().get(0).getWrittenDate()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("2. 마감 임박 업무 조회 - name 필드와 Instant 타입이 정확히 매핑된다")
+    void getUpcomingTasks_Success() {
+        Task task = Task.builder()
+                .id(1L).name("마감 업무").status(TaskStatus.TODO).project(testProject)
+                .dueDate(Instant.now()).build();
+        given(taskRepository.findUpcomingTasksByUserId(anyString(), anyList())).willReturn(List.of(task));
+
+        UpcomingTaskListRes result = dashboardService.getUpcomingTasks(userId);
+
+        assertThat(result.tasks()).hasSize(1);
+        assertThat(result.tasks().get(0).title()).isEqualTo("마감 업무");
+    }
+
+    @Test
+    @DisplayName("3. 알림 목록 조회 - 수신자의 모든 알림을 가져온다")
+    void getRecentNotifications_Success() {
+        Notification notification = Notification.builder()
+                .id(1L).content("새로운 메시지").project(testProject).isRead(false).build();
+        given(notificationRepository.findAllByReceiverRecordId(userId)).willReturn(List.of(notification));
+
+        NotificationListRes result = dashboardService.getRecentNotifications(userId);
+
+        assertThat(result.notifications()).hasSize(1);
+        assertThat(result.notifications().get(0).message()).isEqualTo("새로운 메시지");
+    }
+
+    @Test
+    @DisplayName("4. 날짜별 일정 조회 - 업무와 회의가 통합되고 시간순 정렬된다")
+    void getDailySchedules_Success() {
+        Instant now = Instant.now();
+        Task task = Task.builder()
+                .id(1L).name("오후 업무").project(testProject).dueDate(now.plus(5, ChronoUnit.HOURS)).build();
+        Meeting meeting = Meeting.builder()
+                .id(1L).title("오전 회의").project(testProject)
+                .meetingDate(now.plus(1, ChronoUnit.HOURS)).build();
+
+        given(taskRepository.findAllByMemberAndDate(anyString(), any(), any())).willReturn(List.of(task));
+        given(meetingRepository.findAllByMemberAndDate(anyString(), any(), any())).willReturn(List.of(meeting));
+
+        DailyScheduleListRes result = dashboardService.getDailySchedules(userId, now);
+
+        assertThat(result.schedules()).hasSize(2);
+        assertThat(result.schedules().get(0).title()).contains("[회의]");
+        assertThat(result.schedules().get(1).title()).contains("[업무]");
+    }
+}

--- a/src/test/java/com/connecteamed/server/domain/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/meeting/service/MeetingServiceTest.java
@@ -8,6 +8,8 @@ import com.connecteamed.server.domain.meeting.repository.MeetingAgendaRepository
 import com.connecteamed.server.domain.meeting.repository.MeetingAttendeeRepository;
 import com.connecteamed.server.domain.meeting.repository.MeetingRepository;
 import com.connecteamed.server.domain.project.entity.Project;
+import com.connecteamed.server.domain.project.entity.ProjectMember;
+import com.connecteamed.server.domain.project.repository.ProjectMemberRepository;
 import com.connecteamed.server.domain.project.repository.ProjectRepository;
 import com.connecteamed.server.global.apiPayload.code.GeneralErrorCode;
 import com.connecteamed.server.global.apiPayload.exception.GeneralException;
@@ -38,6 +40,7 @@ class MeetingServiceTest {
     @Mock private MeetingAgendaRepository meetingAgendaRepository;
     @Mock private MeetingAttendeeRepository meetingAttendeeRepository;
     @Mock private ProjectRepository projectRepository;
+    @Mock private ProjectMemberRepository projectMemberRepository;
 
     @InjectMocks private MeetingService meetingService;
 
@@ -48,8 +51,10 @@ class MeetingServiceTest {
         Long projectId = 1L;
         var req = new MeetingCreateReq(projectId,"주간 회의", java.time.Instant.parse("2026-01-15T10:00:00Z"), List.of("안건1"), List.of(1L, 2L));
         Project projectRef = mock(Project.class);
+        ProjectMember memberRef = mock(ProjectMember.class);
 
         given(projectRepository.findById(projectId)).willReturn(Optional.of(projectRef));
+        given(projectMemberRepository.findById(any())).willReturn(Optional.of(memberRef));
         given(meetingRepository.save(any(Meeting.class))).willAnswer(invocation -> {
             Meeting m = invocation.getArgument(0);
             ReflectionTestUtils.setField(m, "id", 100L);
@@ -67,7 +72,6 @@ class MeetingServiceTest {
         Meeting saved = captor.getValue();
         assertThat(saved.getTitle()).isEqualTo("주간 회의");
         assertThat(res.meetingId()).isEqualTo(100L);
-        then(meetingAttendeeRepository).should().saveAll(any());
     }
 
     @Test
@@ -95,7 +99,6 @@ class MeetingServiceTest {
 
         // then
         assertThat(existingMeeting.getTitle()).isEqualTo("수정 제목");
-        then(meetingAttendeeRepository).should().deleteAllByMeeting(existingMeeting);
     }
 
     @Test


### PR DESCRIPTION
## 📌 PR 요약
- 대시보드 핵심 위젯 API 구현: 회고, 다가오는 업무, 최근 알림, 날짜별 일정 조회 기능
- 복합 도메인 쿼리 최적화: Task와 Meeting 데이터를 통합 조회하기 위한 전용 쿼리 구현
- 단위 테스트 기반 검증: Mockito를 활용하여 서비스 계층의 비즈니스 로직 및 데이터 정렬 로직 검증

## 🔧 변경 사항
- 대시보드 도메인 서비스 구현
- 리포지토리 레이어 최적화 및 수정: 단방향 연관 고나계 조인 처리, N+1 문제 방지

## 📋 작업 상세 내용
- [x] 대시보드 컨트롤러 및 API 구현
- [x] 간접 참조 조인 로직 해결: MeetingAttendee -> Member로 이어지는 구조에서 ProjectMember를 활용하여 조인 쿼리 구현
- [x] 테스트 코드 작성 및 검증

## 🔗 관련 이슈
- closed #35 

## 📝 기타