### PR TITLE
[Fix] project: 프로젝트 생성시 생성자 projectMeber에 추가

### DIFF
--- a/src/main/java/com/connecteamed/server/domain/project/service/ProjectService.java
+++ b/src/main/java/com/connecteamed/server/domain/project/service/ProjectService.java
@@ -7,6 +7,7 @@ import com.connecteamed.server.domain.project.dto.ProjectCreateReq;
 import com.connecteamed.server.domain.project.dto.ProjectRes;
 import com.connecteamed.server.domain.project.dto.ProjectUpdateReq;
 import com.connecteamed.server.domain.project.entity.Project;
+import com.connecteamed.server.domain.project.entity.ProjectMember;
 import com.connecteamed.server.domain.project.entity.ProjectRequiredRole;
 import com.connecteamed.server.domain.project.entity.ProjectRole;
 import com.connecteamed.server.domain.project.repository.ProjectMemberRepository;
@@ -88,6 +89,14 @@ public class ProjectService {
 
         Project savedProject = projectRepository.save(project);
         log.info("[ProjectService] Project created successfully: id={}, name={}", savedProject.getId(), savedProject.getName());
+
+        projectMemberRepository.findByProject_IdAndMember_Id(savedProject.getId(), owner.getId())
+                .orElseGet(() -> projectMemberRepository.save(
+                        ProjectMember.builder()
+                                .project(savedProject)
+                                .member(owner)
+                                .build()
+                ));
 
         // 3. 필요 역할 등록
         if (createReq.getRequiredRoleNames() != null && !createReq.getRequiredRoleNames().isEmpty()) {

--- a/src/main/java/com/connecteamed/server/domain/project/service/ProjectService.java
+++ b/src/main/java/com/connecteamed/server/domain/project/service/ProjectService.java
@@ -90,13 +90,11 @@ public class ProjectService {
         Project savedProject = projectRepository.save(project);
         log.info("[ProjectService] Project created successfully: id={}, name={}", savedProject.getId(), savedProject.getName());
 
-        projectMemberRepository.findByProject_IdAndMember_Id(savedProject.getId(), owner.getId())
-                .orElseGet(() -> projectMemberRepository.save(
-                        ProjectMember.builder()
-                                .project(savedProject)
-                                .member(owner)
-                                .build()
-                ));
+        ProjectMember projectOwnerAsMember = ProjectMember.builder()
+                .project(savedProject)
+                .member(owner)
+                .build();
+        projectMemberRepository.save(projectOwnerAsMember);
 
         // 3. 필요 역할 등록
         if (createReq.getRequiredRoleNames() != null && !createReq.getRequiredRoleNames().isEmpty()) {


### PR DESCRIPTION
## 📌 PR 요약
- 프로젝트 생성 후 내가 참여한 프로젝트(팀) 목록 조회에 생상자가 만든 프로젝트가 나오지 않아 코드 몇줄 추가 했습니다!
- project_member 테이블에 생성된 프로젝트 id와 생성자의 id를 넣는 로직을 추가했습니다.

## 🔧 변경 사항
-  ProjectService에 몇줄 추가했습니다.

## 📋 작업 상세 내용

## 🔗 관련 이슈

- closed #46 


