### PR TITLE
[Refactor]  로그인/회원가입 memberId 응답 타입 변경

### DIFF
--- a/src/main/java/com/connecteamed/server/global/auth/controller/AuthController.java
+++ b/src/main/java/com/connecteamed/server/global/auth/controller/AuthController.java
@@ -37,7 +37,7 @@ public class AuthController {
                             mediaType = "application/json",
                             examples = @ExampleObject(
                                     name = "회원가입 성공 예시",
-                                    value = "{ \"status\": \"success\", \"data\": { \"memberId\": \"b4179fa3-ae3...\", \"name\": \"홍길동\" }, \"message\": \"회원가입이 성공적으로 완료되었습니다.\", \"code\": null }"
+                                    value = "{ \"status\": \"success\", \"data\": { \"memberId\": 1, \"name\": \"홍길동\" }, \"message\": \"회원가입이 성공적으로 완료되었습니다.\", \"code\": null }"
                             )
                     )),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (필드 누락 등)"),
@@ -58,7 +58,7 @@ public class AuthController {
             mediaType = "application/json",
             examples = @ExampleObject(
                     name = "로그인 성공 예시",
-                    value = "{ \"status\": \"success\", \"data\": { \"memberId\": \"b4179fa3-ae3...\",\"accessToken\": \"eyJhbGci...\", \"refreshToken\": \"eyJhbGci...\",\"grantType\": \"Bearer\",\"expiresIn\": 14400 }, \"message\": \"로그인이 완료되었습니다.\", \"code\": null }"
+                    value = "{ \"status\": \"success\", \"data\": { \"memberId\": 1,\"accessToken\": \"eyJhbGci...\", \"refreshToken\": \"eyJhbGci...\",\"grantType\": \"Bearer\",\"expiresIn\": 14400 }, \"message\": \"로그인이 완료되었습니다.\", \"code\": null }"
             )
     )
             ),

--- a/src/main/java/com/connecteamed/server/global/auth/converter/AuthConverter.java
+++ b/src/main/java/com/connecteamed/server/global/auth/converter/AuthConverter.java
@@ -24,7 +24,7 @@ public class AuthConverter {
     // 2. [Entity -> Response DTO] 회원가입 결과 반환용
     public static AuthResDTO.JoinDTO toJoinResultDTO(Member member) {
         return AuthResDTO.JoinDTO.builder()
-                .memberId(member.getPublicId())
+                .memberId(member.getId())
                 .name(member.getName())
                 .build();
     }
@@ -34,7 +34,7 @@ public class AuthConverter {
     //로그인
     public static AuthResDTO.LoginDTO toLoginDTO(Member member, String accessToken, String refreshToken,Long expiresIn) {
         return AuthResDTO.LoginDTO.builder()
-                .memberId(member.getPublicId()) // UUID 매핑
+                .memberId(member.getId())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .grantType("Bearer")

--- a/src/main/java/com/connecteamed/server/global/auth/dto/AuthResDTO.java
+++ b/src/main/java/com/connecteamed/server/global/auth/dto/AuthResDTO.java
@@ -9,7 +9,7 @@ public class AuthResDTO {
     //회원가입
     @Builder
     public record JoinDTO(
-            UUID memberId,
+            Long memberId,
             String name
     ){}
 
@@ -18,7 +18,7 @@ public class AuthResDTO {
     //로그인
     @Builder
     public record LoginDTO(
-            UUID memberId,
+            Long memberId,
             String accessToken,
             String refreshToken,
             String grantType,

--- a/src/main/java/com/connecteamed/server/global/auth/dto/AuthResDTO.java
+++ b/src/main/java/com/connecteamed/server/global/auth/dto/AuthResDTO.java
@@ -2,8 +2,6 @@ package com.connecteamed.server.global.auth.dto;
 
 import lombok.Builder;
 
-import java.util.UUID;
-
 public class AuthResDTO {
 
     //회원가입

--- a/src/test/java/com/connecteamed/server/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/connecteamed/server/domain/auth/controller/AuthControllerTest.java
@@ -48,7 +48,7 @@ class AuthControllerTest {
     @DisplayName("로그인 성공 - 올바른 JSON 규격 확인")
     void login_Success() throws Exception {
         AuthReqDTO.LoginDTO request = new AuthReqDTO.LoginDTO("testId", "password123");
-        UUID testMemberId = UUID.randomUUID();
+        Long testMemberId = 1L;
         AuthResDTO.LoginDTO response = new AuthResDTO.LoginDTO(
                 testMemberId,
                 "eyJhbGci...",
@@ -64,7 +64,7 @@ class AuthControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("success"))
-                .andExpect(jsonPath("$.data.memberId").value(testMemberId.toString()))
+                .andExpect(jsonPath("$.data.memberId").value(1L))
                 .andExpect(jsonPath("$.data.accessToken").value("eyJhbGci..."))
                 .andExpect(jsonPath("$.data.refreshToken").value("eyJhbGci..."))
                 .andExpect(jsonPath("$.data.grantType").value("Bearer"))
@@ -155,7 +155,7 @@ class AuthControllerTest {
                 "password123!"
         );
 
-        UUID testMemberId = UUID.randomUUID();
+        Long testMemberId = 1L;
         AuthResDTO.JoinDTO response = new AuthResDTO.JoinDTO(testMemberId,"testUser");
 
         when(authCommandService.signup(any())).thenReturn(response);
@@ -166,7 +166,7 @@ class AuthControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("success"))
-                .andExpect(jsonPath("$.data.memberId").value(testMemberId.toString()))
+                .andExpect(jsonPath("$.data.memberId").value(1L))
                 .andExpect(jsonPath("$.data.name").value("testUser"))
                 .andExpect(jsonPath("$.message").value("회원가입이 완료되었습니다."))
                 .andExpect(jsonPath("$.code").value(Matchers.nullValue()));

--- a/src/test/java/com/connecteamed/server/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/connecteamed/server/domain/auth/controller/AuthControllerTest.java
@@ -18,7 +18,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -64,7 +63,7 @@ class AuthControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("success"))
-                .andExpect(jsonPath("$.data.memberId").value(1L))
+                .andExpect(jsonPath("$.data.memberId").value(testMemberId))
                 .andExpect(jsonPath("$.data.accessToken").value("eyJhbGci..."))
                 .andExpect(jsonPath("$.data.refreshToken").value("eyJhbGci..."))
                 .andExpect(jsonPath("$.data.grantType").value("Bearer"))
@@ -166,7 +165,7 @@ class AuthControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("success"))
-                .andExpect(jsonPath("$.data.memberId").value(1L))
+                .andExpect(jsonPath("$.data.memberId").value(testMemberId))
                 .andExpect(jsonPath("$.data.name").value("testUser"))
                 .andExpect(jsonPath("$.message").value("회원가입이 완료되었습니다."))
                 .andExpect(jsonPath("$.code").value(Matchers.nullValue()));


### PR DESCRIPTION
## 📌 PR 요약
- 로그인/회원가입 성공시 응답으로 주는 memberId 필드의 타입을 UUID에서 Long으로 변경했습니다

## 🔧 변경 사항
- 클라이언트에게 전달하는 ID타입을 모두 Long으로 통일하기로 결정함에 따른 변경

## 📋 작업 상세 내용
- [x] 반환 Id타입변경
- [x] 테스트 코드에 변경사항 반영

## 🔗 관련 이슈
- 관련있는 이슈 번호(#000)을 작성합니다.
- closed #51 

## 📝 기타
