### PR TITLE
[Feat]/49 deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,55 +1,18 @@
 services:
-  db:
-    image: postgres:16
-    container_name: connecteamed-be-db
-    environment:
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    ports:
-      - "5432:5432"
-    volumes:
-      - connecteamed-be-db:/var/lib/postgresql/data
-    networks:
-      - connecteamed-network
-
-  pgadmin:
-    image: dpage/pgadmin4:latest
-    container_name: connecteamed-pgadmin
-    environment:
-      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@example.com}
-      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
-    ports:
-      - "${PGADMIN_PORT:-5050}:80"
-    networks:
-      - connecteamed-network
-    depends_on:
-      - db
-
   app:
-    ports:
-      - "8080:8080"
     build: .
     container_name: connecteamed-be-app
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
     environment:
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/${POSTGRES_DB}
-      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USER}
-      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+      - SPRING_DATASOURCE_USERNAME=${DB_USER}
+      - SPRING_DATASOURCE_PASSWORD=${DB_PASSWORD}
       - GEMINI_API_KEY=${GEMINI_API_KEY}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
       - APP_S3_ACCESS_KEY=${APP_S3_ACCESS_KEY}
       - APP_S3_SECRET_KEY=${APP_S3_SECRET_KEY}
       - APP_S3_BUCKET=${APP_S3_BUCKET}
       - APP_S3_REGION=${APP_S3_REGION}
-    networks:
-      - connecteamed-network
-    depends_on:
-      - db
-
-networks:
-  connecteamed-network:
-    name: ${DOCKER_NETWORK:-connecteamed-network}
-    driver: bridge
-
-volumes:
-  connecteamed-be-db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       - db
 
   app:
+    ports:
+      - "8080:8080"
     build: .
     container_name: connecteamed-be-app
     environment:

--- a/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
@@ -25,6 +25,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor // JwtUtil과 Service 주입을 위해 필요합니다.
@@ -97,6 +103,25 @@ public class SecurityConfig {
         ;
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOrigins(List.of(
+                "http://localhost:5173",
+                "http://127.0.0.1:5173"
+
+        ));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true); 
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 
     //공통 설정

--- a/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
@@ -119,7 +119,7 @@ public class SecurityConfig {
 
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-        config.setAllowedHeaders(List.of("*"));
+        config.setAllowedHeaders(List.of("Authorization", "Refresh-Token", "Content-Type", "Accept", "Origin", "X-Requested-With"));
         config.setAllowCredentials(true); 
         config.setMaxAge(3600L);
 

--- a/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
         configureCommonSecurity(http);
         http
             .authorizeHttpRequests(auth -> auth
+                .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers(
                     "/", "/index.html", "/document.html",
                     "/css/**", "/js/**", "/images/**", "/favicon.ico", "/error",
@@ -76,6 +77,7 @@ public class SecurityConfig {
         configureCommonSecurity(http);
         http
             .authorizeHttpRequests(auth -> auth
+                .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers(
                     "/", "/index.html", "/document.html",
                     "/css/**", "/js/**", "/images/**", "/favicon.ico", "/error",
@@ -111,7 +113,8 @@ public class SecurityConfig {
 
         config.setAllowedOrigins(List.of(
                 "http://localhost:5173",
-                "http://127.0.0.1:5173"
+                "http://127.0.0.1:5173",
+                "https://api.connecteamed.shop"
 
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
@@ -128,7 +131,7 @@ public class SecurityConfig {
     private void configureCommonSecurity(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
-                .cors(Customizer.withDefaults())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session

--- a/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
@@ -114,7 +114,8 @@ public class SecurityConfig {
         config.setAllowedOrigins(List.of(
                 "http://localhost:5173",
                 "http://127.0.0.1:5173",
-                "https://api.connecteamed.shop"
+                "https://api.connecteamed.shop",
+                "https://connecteamed.shop"
 
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));


### PR DESCRIPTION
## 📌 PR 요약
- Swagger Try it out 요청이 CORS(preflight)로 막히는 문제를 해결하기 위해 SecurityConfig의 CORS 설정을 보완했습니다.
- docker-compose를 Lightsail 외부 Postgres(DB) 연결 방식으로 변경

## 🔧 변경 사항
- CORS 허용 Origin에 운영 API 도메인(api.connecteamed.shop) 및 필요 시 http 접속 케이스를 추가했습니다.
- Preflight(OPTIONS) 요청이 인증/필터에 의해 차단되지 않도록 OPTIONS 요청을 전역 허용했습니다.
- Security 설정에서 CORS가 CorsConfigurationSource를 확실히 참조하도록 설정을 명시적으로 연결했습니다.

- 로컬 DB 컨테이너(db/pgadmin) 의존 제거(외부 Lightsail DB 사용)
- app 컨테이너에 .env 적용(env_file) 추가
- DB 접속 정보를 jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME} 형태로 변경
- DB 계정/비밀번호 및 기타 환경변수(GEMINI/JWT/S3)도 .env 기반으로 주입하도록 정리

## 📋 작업 상세 내용
- [x] `CorsConfigurationSource`의 `allowedOrigins`에 아래 항목 추가
  - `https://api.connecteamed.shop`
- [x] `SecurityFilterChain`에 `HttpMethod.OPTIONS, "/**"` 전역 `permitAll()` 추가 (local / non-local 모두)
- [x] 공통 시큐리티 설정에서 `.cors(cors -> cors.configurationSource(corsConfigurationSource()))`로 명시 연결
- [x] docker-compose.yml에서 app 서비스만 사용하도록 구성
- [x] DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD를 .env로 관리
- [x] 기존 도커 내부 db:5432 의존성 제거 후 외부 DB로 정상 구동 확인

## 🔗 관련 이슈
- closed #49 

## 📝 기타
