### PR TITLE
[Feat] 소셜 로그인 API

### DIFF
--- a/src/main/java/com/connecteamed/server/global/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/connecteamed/server/global/auth/CustomOAuth2UserService.java
@@ -1,0 +1,72 @@
+package com.connecteamed.server.global.auth;
+
+import com.connecteamed.server.domain.member.entity.Member;
+import com.connecteamed.server.domain.member.enums.SocialType;
+import com.connecteamed.server.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+//spring에서 access Token 얻은 후 사용자 정보를 얻기 위해 자동으로 호출하는 로직
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+
+    private final MemberRepository memberRepository;
+
+
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        String email;
+        String name;
+        SocialType socialType;
+
+
+        if ("kakao".equals(registrationId)) {
+            // 카카오 로그인인 경우 데이터 추출
+            Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+            Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+            email = (String) kakaoAccount.get("email");
+            name = (String) profile.get("nickname"); // 실명 대신 닉네임 활용
+            socialType = SocialType.KAKAO;
+        } else {
+            // 구글 로그인인 경우 데이터 추출
+            email = (String) attributes.get("email");
+            name = (String) attributes.get("name");
+            socialType = SocialType.GOOGLE;
+        }
+
+        SocialType finalSocialType = socialType;
+        Member member = memberRepository.findByLoginId(email)
+                .orElseGet(() -> registerNewMember(email, name, finalSocialType));
+
+        return new CustomUserDetails(member, attributes);
+    }
+
+    private Member registerNewMember(String email, String name, SocialType socialType) {
+        // 소셜 로그인 유저는 loginId에 email을 할당하여 기존 로직과 호환시킴
+        Member newMember = Member.builder()
+                .loginId(email)       // 아이디를 이메일로 대체
+                .name(name)
+                .socialType(socialType)
+                .build();
+
+        return memberRepository.save(newMember);
+    }
+
+}

--- a/src/main/java/com/connecteamed/server/global/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/connecteamed/server/global/auth/CustomOAuth2UserService.java
@@ -44,11 +44,18 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             email = (String) kakaoAccount.get("email");
             name = (String) profile.get("nickname"); // 실명 대신 닉네임 활용
             socialType = SocialType.KAKAO;
-        } else {
-            // 구글 로그인인 경우 데이터 추출
+        } else if ("google".equals(registrationId)) { // 2. 구글 명시적 처리
             email = (String) attributes.get("email");
             name = (String) attributes.get("name");
             socialType = SocialType.GOOGLE;
+
+        } else {
+            // 지원하지 않는 소셜 로그인 공급자
+            throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인 공급자입니다: " + registrationId);
+        }
+
+        if (email == null) {
+            throw new OAuth2AuthenticationException("소셜 서비스로부터 이메일 정보를 불러올 수 없습니다.");
         }
 
         SocialType finalSocialType = socialType;

--- a/src/main/java/com/connecteamed/server/global/auth/CustomUserDetails.java
+++ b/src/main/java/com/connecteamed/server/global/auth/CustomUserDetails.java
@@ -5,12 +5,15 @@ import com.connecteamed.server.domain.member.entity.Member;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 
-public record CustomUserDetails(Member member) implements UserDetails {
+public record CustomUserDetails(Member member,
+                                Map<String, Object> attributes)
+        implements UserDetails, OAuth2User {
 
 
     @Override
@@ -19,6 +22,19 @@ public record CustomUserDetails(Member member) implements UserDetails {
         // 나중에 관리자 기능이 필요해지면 엔티티에 필드를 추가
         return Collections.singletonList(new SimpleGrantedAuthority("USER"));
     }
+
+    // 기존 자체 로그인용 생성자 (attributes를 빈 값으로 넘김)
+    public CustomUserDetails(Member member) {
+        this(member, java.util.Collections.emptyMap());
+    }
+
+    //소셜 로그인 용
+    @Override
+    public Map<String, Object> getAttributes() { return attributes; }
+
+    //소셜 로그인 용
+    @Override
+    public String getName() { return member.getLoginId(); }
 
     @Override
     public String getPassword() {

--- a/src/main/java/com/connecteamed/server/global/auth/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/connecteamed/server/global/auth/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,50 @@
+package com.connecteamed.server.global.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+//소셜로 부터 받은 authentication을 바탕으로 클라이언트에게 로그인 정보를 내려주는 로직
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final JwtUtil jwtUtil;
+
+    @Value("${app.oauth2.frontend-redirect-url}")
+    private String frontendRedirectUrl;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        String accessToken = jwtUtil.createAccessToken(userDetails);
+        String refreshToken = jwtUtil.createRefreshToken(userDetails);
+
+        Long memberId = userDetails.member().getId();
+        Long expiresIn = jwtUtil.getAccessTokenExpirationMillis() / 1000;
+
+        // 리다이렉트 url 생성
+        String targetUrl = UriComponentsBuilder.fromUriString(frontendRedirectUrl)
+                .queryParam("memberId", memberId)
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .queryParam("grantType", "Bearer")
+                .queryParam("expiresIn", expiresIn)
+                .build()
+                .encode(StandardCharsets.UTF_8)
+                .toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/com/connecteamed/server/global/auth/controller/AuthController.java
+++ b/src/main/java/com/connecteamed/server/global/auth/controller/AuthController.java
@@ -13,10 +13,13 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -128,4 +131,51 @@ public class AuthController {
 
         return ApiResponse.onSuccess(AuthSuccessCode.REISSUE_SUCCESS, result);
     }
+
+
+    @Operation(
+            summary = "구글 로그인",
+            description =
+                    """
+                            이 API는 `Try it out` 으로 테스트가 불가능합니다. 테스트 필요시 브라우저 주소창에 직접 입력하여 접근하세요.
+                            
+                            ---\s
+                            Redirect URL: {FRONT_URL}/login/callback
+                            
+                            성공 시 전달 파라미터 (Redirect Query String)
+                            | 파라미터명 | 타입 | 설명 | 예시 |
+                            | :--- | :--- | :--- | :--- |
+                            | **memberId** | Long | 사용자 식별자 | 1 |
+                            | **accessToken** | String | API 인증용 토큰 | eyJhbGci... |
+                            | **refreshToken** | String | 토큰 갱신용 토큰 | eyJhbGci... |
+                            | **grantType** | String | 인증타입 | Bearer |
+                            | **expiresIn** | Long | 만료 시간(초) | 14400 |
+                            ---"""
+    )
+    @GetMapping("/api/auth/login/google")
+    public void googleLogin() {}
+
+    @Operation(
+            summary = "카카오 로그인",
+            description =
+                    """
+                            이 API는 `Try it out` 으로 테스트가 불가능합니다. 테스트 필요시 브라우저 주소창에 직접 입력하여 접근하세요.
+                            
+                            ---\s
+                            Redirect URL: {FRONT_URL}/login/callback
+                            
+                            성공 시 전달 파라미터 (Redirect Query String)
+                            | 파라미터명 | 타입 | 설명 | 예시 |
+                            | :--- | :--- | :--- | :--- |
+                            | **memberId** | Long | 사용자 식별자 | 1 |
+                            | **accessToken** | String | API 인증용 토큰 | eyJhbGci... |
+                            | **refreshToken** | String | 토큰 갱신용 토큰 | eyJhbGci... |
+                            | **grantType** | String | 인증타입 | Bearer |
+                            | **expiresIn** | Long | 만료 시간(초) | 14400 |
+                            ---"""
+    )
+    @GetMapping("/api/auth/login/kakao")
+    public void kakaoLogin() {}
+
+
 }

--- a/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/connecteamed/server/global/config/SecurityConfig.java
@@ -2,10 +2,7 @@ package com.connecteamed.server.global.config;
 
 import com.connecteamed.server.domain.token.repository.BlacklistedTokenRepository;
 import com.connecteamed.server.global.apiPayload.ApiResponse;
-import com.connecteamed.server.global.auth.JwtAuthenticationFilter;
-import com.connecteamed.server.global.auth.JwtLogoutHandler;
-import com.connecteamed.server.global.auth.JwtUtil;
-import com.connecteamed.server.global.auth.CustomUserDetailsService;
+import com.connecteamed.server.global.auth.*;
 import com.connecteamed.server.global.auth.exception.code.AuthErrorCode;
 import com.connecteamed.server.global.auth.exception.code.AuthSuccessCode;
 import com.connecteamed.server.global.util.FilterResponseUtils;
@@ -15,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -38,6 +34,10 @@ public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final CustomUserDetailsService customUserDetailsService;
+
+    //소셜 로그인용
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
 
     private final JwtLogoutHandler jwtLogoutHandler;
     private final BlacklistedTokenRepository blacklistedTokenRepository;
@@ -84,8 +84,16 @@ public class SecurityConfig {
                     "/docs", "/docs/**", "/swagger-ui/**", "/v3/api-docs/**"
                 ).permitAll()
                 // 로그인/회원가입 같은 것만 예외로 오픈
-                .requestMatchers("/api/auth/login","/api/auth/refresh","/api/auth/signup","/api/members/check-id").permitAll()
+                .requestMatchers("/api/auth/login","/login/oauth2/code/**","/api/auth/refresh","/api/auth/signup","/api/members/check-id").permitAll()
                 .anyRequest().authenticated()
+                )
+                // Oauth2 관련 설정
+                .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(authorization -> authorization
+                                .baseUri("/api/auth/login")
+                        )
+                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService)) //
+                        .successHandler(oAuth2AuthenticationSuccessHandler) //
                 )
                 // JWT 필터 추가
                 .addFilterBefore(new JwtAuthenticationFilter(jwtUtil, customUserDetailsService, blacklistedTokenRepository,filterResponseUtils),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,6 +21,33 @@ spring:
         highlight_sql: true
     open-in-view: false
 
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope:
+              - email
+              - profile
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            client-name: Kakao
+            scope:
+              - account_email
+              - profile_nickname
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id # 카카오 유저 고유번호
+
 jwt:
   token:
     secretKey: ${JWT_SECRET_KEY}
@@ -39,6 +66,11 @@ server:
   port: 8080
 
 app:
+
+  oauth2:
+    frontend-redirect-url: ${FRONTEND_REDIRECT_URL}
+
+
   s3:
     region: ${APP_S3_REGION:ap-northeast-2}
     bucket: ${APP_S3_BUCKET}

--- a/src/test/java/com/connecteamed/server/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,149 @@
+package com.connecteamed.server.domain.auth.service;
+
+import com.connecteamed.server.domain.member.entity.Member;
+import com.connecteamed.server.domain.member.enums.SocialType;
+import com.connecteamed.server.domain.member.repository.MemberRepository;
+import com.connecteamed.server.global.auth.CustomOAuth2UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.web.client.RestOperations;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    @Spy
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @Mock
+    private RestOperations restOperations;
+
+    @Test
+    @DisplayName("카카오 유저 정보를 받으면 DB에 KAKAO 타입으로 저장되어야 한다")
+    void kakao_login_test() {
+
+        // RestOperations 주입
+        customOAuth2UserService.setRestOperations(restOperations);
+
+        //  액세스 토큰 생성
+        OAuth2AccessToken accessToken = new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER,
+                "fake-token",
+                Instant.now(),
+                Instant.now().plusSeconds(3600)
+        );
+
+        ClientRegistration clientRegistration = ClientRegistration.withRegistrationId("kakao")
+                .clientId("test")
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("test")
+                .authorizationUri("test")
+                .tokenUri("test")
+                .userInfoUri("https://kapi.kakao.com/v2/user/me")
+                .userNameAttributeName("id")
+                .build();
+
+        OAuth2UserRequest userRequest = new OAuth2UserRequest(clientRegistration, accessToken);
+
+
+        Map<String, Object> attributes = Map.of(
+                "id", 12345L,
+                "kakao_account", Map.of(
+                        "email", "test@kakao.com",
+                        "profile", Map.of("nickname", "테스트닉네임")
+                )
+        );
+
+        ResponseEntity<Map<String, Object>> responseEntity = new ResponseEntity<>(attributes, HttpStatus.OK);
+
+        given(restOperations.exchange(any(RequestEntity.class), any(ParameterizedTypeReference.class)))
+                .willReturn(responseEntity);
+
+        // 신규 회원으로 가정
+        given(memberRepository.findByLoginId("test@kakao.com")).willReturn(Optional.empty());
+        given(memberRepository.save(any(Member.class))).willAnswer(inv -> inv.getArgument(0));
+
+        customOAuth2UserService.loadUser(userRequest);
+
+        //1. social type kakao로 저장되는지, 2. 로그인 Id 로직대로 저장되는지 확인
+        verify(memberRepository).save(argThat(member ->
+                member.getSocialType() == SocialType.KAKAO &&
+                        member.getLoginId().equals("test@kakao.com")
+        ));
+    }
+
+
+
+    @Test
+    @DisplayName("구글 유저 정보를 받으면 DB에 GOOGLE 타입으로 저장되어야 한다")
+    void google_login_test() {
+        customOAuth2UserService.setRestOperations(restOperations);
+
+        OAuth2AccessToken accessToken = new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER,
+                "fake-google-token",
+                Instant.now(),
+                Instant.now().plusSeconds(3600)
+        );
+
+        ClientRegistration clientRegistration = ClientRegistration.withRegistrationId("google")
+                .clientId("google-client-id")
+                .clientSecret("google-client-secret")
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("http://localhost:8080/login/oauth2/code/google")
+                .authorizationUri("https://accounts.google.com/o/oauth2/v2/auth")
+                .tokenUri("https://www.googleapis.com/oauth2/v4/token")
+                .userInfoUri("https://www.googleapis.com/oauth2/v3/userinfo")
+                .userNameAttributeName("sub")
+                .build();
+
+        OAuth2UserRequest userRequest = new OAuth2UserRequest(clientRegistration, accessToken);
+
+        Map<String, Object> attributes = Map.of(
+                "sub", "google-unique-id-123",
+                "email", "test@google.com",
+                "name", "구글유저"
+        );
+
+        ResponseEntity<Map<String, Object>> responseEntity = new ResponseEntity<>(attributes, HttpStatus.OK);
+
+        given(restOperations.exchange(any(RequestEntity.class), any(ParameterizedTypeReference.class)))
+                .willReturn(responseEntity);
+
+        given(memberRepository.findByLoginId("test@google.com")).willReturn(Optional.empty());
+        given(memberRepository.save(any(Member.class))).willAnswer(inv -> inv.getArgument(0));
+
+
+        customOAuth2UserService.loadUser(userRequest);
+
+        //SocialType.GOOGLE로 잘 저장되는지 확인
+        verify(memberRepository).save(argThat(member ->
+                member.getSocialType() == SocialType.GOOGLE &&
+                        member.getLoginId().equals("test@google.com") &&
+                        member.getName().equals("구글유저")
+        ));
+    }
+}

--- a/src/test/java/com/connecteamed/server/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/auth/service/AuthServiceTest.java
@@ -35,7 +35,6 @@ public class AuthServiceTest {
     private MemberRepository memberRepository;
 
     @InjectMocks
-    @Spy
     private CustomOAuth2UserService customOAuth2UserService;
 
     @Mock

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -18,6 +18,26 @@ spring:
     show-sql: false
     open-in-view: false
 
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: dummy-google-id
+            client-secret: dummy-google-secret
+          kakao:
+            client-id: dummy-kakao-id
+            client-secret: dummy-kakao-secret
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
 jwt:
   token:
     secretKey: static_test_key_for_unit_testing_purposes_only_12345
@@ -32,6 +52,7 @@ springdoc:
 server:
   port: 8080
 
+
 app:
   s3:
     region: ap-northeast-2
@@ -42,4 +63,7 @@ app:
   test:
     login-id: test@example.com
     user-name: 테스트사용자
+
+  oauth2:
+    frontend-redirect-url: http://localhost:5173/login/callback
 


### PR DESCRIPTION
## 📌 PR 요약
- 카카오, 구글 소셜 로그인 API를 구현하였습니다.

## 🔧 변경 사항
- 자체 로그인이 json 방식으로 데이터를 내려주고 있으므로 소셜 로그인도 프론트가 직접 인가 코드를 백엔드에게 전달하는 방식으로 구현하여 json으로 프론트에게 로그인 정보를 내려주는 것이 좋겠지만, 프론트분들이 좀 바쁜 것 같으셔서 백엔드에서 인가 로직을 처리하고 프론트에게 redirect url 에 로그인 response를 실어보내는 방식으로 구현하였습니다. url에 보내주는 data 구조는 자체로그인 response data 구조와 동일합니다.
- Spring Boot에서 제공하는 Spring Security OAuth2 Client 라이브러리를 활용하였습니다.

## 📋 작업 상세 내용
- [x] 구글 로그인 구현
- [x] 카카오 로그인 구현
- [x] 테스트 코드 작성

## 🔗 관련 이슈
- 관련있는 이슈 번호(#000)을 작성합니다.
- closed #66 

## 📝 기타
