### PR TITLE
[Fix] http/https 주소 인식 오류 해결

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -64,7 +64,7 @@ springdoc:
 
 server:
   port: 8080
-
+  forward-headers-strategy: native
 app:
 
   oauth2:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -64,7 +64,7 @@ springdoc:
 
 server:
   port: 8080
-  forward-headers-strategy: native
+  forward-headers-strategy: framework
 app:
 
   oauth2:


### PR DESCRIPTION

## 📌 PR 요약
- https 도메인으로 배포하여도 spring이 주소를 http로 인식하고 있어 소셜 로그인 시도시 공급자에게 redirec_url을 https가 아닌 http로 시작하는 주소로 요청하는 문제가 발생했습니다. 이로 인해 소셜 로그인 error가 발생했습니다. 이를 해결하기 위해 관련 설정을 추가하였습니다

## 🔧 변경 사항
- forward-headers-strategy: native 코드를 추가하여 spring boot가 자신의 프로토콜이 https임을 인지 할 수 있게 합니다

## 📋 작업 상세 내용
- [x] 헤더 설정 추가

## 🔗 관련 이슈
- closed #70 

## 📝 기타

