### PR TITLE
[Feat] 프로젝트 팀 전체/팀원 별 업무 통계 조회 API 구현

### DIFF
--- a/src/main/java/com/connecteamed/server/domain/contribution/code/ContributionErrorCode.java
+++ b/src/main/java/com/connecteamed/server/domain/contribution/code/ContributionErrorCode.java
@@ -1,0 +1,20 @@
+package com.connecteamed.server.domain.contribution.code;
+
+import com.connecteamed.server.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ContributionErrorCode implements BaseErrorCode {
+
+    CONTRIBUTION_ERROR_CODE(HttpStatus.BAD_REQUEST,"CONTRIBUTION_ERROR","요청에 실패하였습니다."),
+    CONTRIBUTION_PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "CONTRIBUTION_PROJECT_NOT_FOUND", "해당 Id의 프로젝트를 찾을 수 없습니다."),
+    ;
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/connecteamed/server/domain/contribution/code/ContributionSuccessCode.java
+++ b/src/main/java/com/connecteamed/server/domain/contribution/code/ContributionSuccessCode.java
@@ -1,0 +1,21 @@
+package com.connecteamed.server.domain.contribution.code;
+
+
+import com.connecteamed.server.global.apiPayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ContributionSuccessCode implements BaseSuccessCode {
+
+
+    CONTRIBUTION_OK(HttpStatus.OK,"CONTRIBUTION_OK","요청에 성공하였습니다."),
+    ;
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/connecteamed/server/domain/contribution/controller/ContributionController.java
+++ b/src/main/java/com/connecteamed/server/domain/contribution/controller/ContributionController.java
@@ -1,16 +1,21 @@
 package com.connecteamed.server.domain.contribution.controller;
 
-import com.connecteamed.server.domain.contribution.dto.CalendarContributionRes;
-import com.connecteamed.server.domain.contribution.dto.ContributionReq;
-import com.connecteamed.server.domain.contribution.dto.ContributionRes;
+import com.connecteamed.server.domain.contribution.code.ContributionSuccessCode;
+import com.connecteamed.server.domain.contribution.dto.*;
 import com.connecteamed.server.domain.contribution.service.ContributionService;
+import com.connecteamed.server.domain.contribution.service.ProjectContributionService;
 import com.connecteamed.server.global.apiPayload.ApiResponse;
 import com.connecteamed.server.global.apiPayload.code.GeneralSuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Contribution", description = "잔디 관련 API")
 @RestController
@@ -19,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 public class ContributionController {
 
     private final ContributionService contributionService;
+    private final ProjectContributionService projectContributionService;
 
     @GetMapping("/calendar")
     @Operation(summary = "연간 잔디 조회", description = "특정 연도의 1월 1일부터 12월 31일까지의 모든 잔디 데이터를 조회합니다.")
@@ -28,4 +34,142 @@ public class ContributionController {
     ) {
         return ApiResponse.onSuccess(GeneralSuccessCode._OK, contributionService.getCalendar(userId, year));
     }
+
+
+    @GetMapping("/{projectId}/individual")
+    @Operation(
+            summary = "프로젝트 팀원별 업무 통계(잔디) 조회",
+            description = "특정 프로젝트에 속한 모든 팀원의 최근 4개월간 잔디 데이터를 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "팀원별 잔디 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "조회 성공 예시",
+                                    value = """
+                    {
+                      "status": "success",
+                      "data": [
+                        {
+                          "id": 1,
+                          "name": "member1",
+                          "contributions": [
+                            { "date": "2026-02-10", "count": 10, "level": 4 },
+                            { "date": "2026-02-09", "count": 2, "level": 1 },
+                            "이후로 계속 이어짐.."
+                          ]
+                        },
+                        {
+                          "id": 3,
+                          "name": "member2",
+                          "contributions": [
+                            { "date": "2026-02-10", "count": 0, "level": 0 },
+                            { "date": "2026-02-09", "count": 2, "level": 1 }
+                          ]
+                        }
+                      ],
+                      "message": "요청에 성공하였습니다.",
+                      "code" : null
+                    }
+                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "팀을 찾을 수 없음(미존재)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "팀 미존재 에러 예시",
+                                    value = """
+                    {
+                      "status": "error",
+                      "data" : null,
+                      "code": "CONTRIBUTION_PROJECT_NOT_FOUND",
+                      "message": "해당 Id의 프로젝트를 찾을 수 없습니다."
+                    }
+                    """
+                            )
+                    )
+            )
+    })
+    public ApiResponse<List<ProjectMemberContributionRes>> getIndividualContributions(
+            @PathVariable Long projectId
+    ) {
+        List<ProjectMemberContributionRes> response = projectContributionService.getProjectMemberContributions(projectId);
+
+        return ApiResponse.onSuccess(ContributionSuccessCode.CONTRIBUTION_OK, response);
+    }
+
+
+    @GetMapping("/{projectId}/entire")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "팀 전체 통계 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "조회 성공 예시",
+                                    value = """
+                    {
+                      "status": "success",
+                      "data": [
+                        { "date": "2026-01-28", "count": 45 },
+                        { "date": "2026-01-29", "count": 32 },
+                        { "date": "2026-01-30", "count": 4 },
+                        { "date": "2026-01-31", "count": 32 },
+                        { "date": "2026-02-01", "count": 5 },
+                        { "date": "2026-02-02", "count": 2 },
+                        { "date": "2026-02-03", "count": 4 },
+                        { "date": "2026-02-04", "count": 32 },
+                        { "date": "2026-02-05", "count": 45 },
+                        { "date": "2026-02-06", "count": 32 },
+                        { "date": "2026-02-07", "count": 15 },
+                        { "date": "2026-02-08", "count": 32 },
+                        { "date": "2026-02-09", "count": 45 },
+                        { "date": "2026-02-10", "count": 2 }
+                      ],
+                      "message": "요청에 성공하였습니다.",
+                      "code": null
+                    }
+                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "팀을 찾을 수 없음(미존재)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "팀 미존재 에러 예시",
+                                    value = """
+                    {
+                      "status": "error",
+                      "data" : null,
+                      "code": "CONTRIBUTION_PROJECT_NOT_FOUND",
+                      "message": "해당 Id의 프로젝트를 찾을 수 없습니다."
+                    }
+                    """
+                            )
+                    )
+            )
+    })
+    @Operation(
+            summary = "팀 전체 업무 통계 조회",
+            description = "최근 2주간 프로젝트 전체 멤버의 일별 기여도 합산을 반환합니다."
+    )
+    public ApiResponse<List<ProjectContributionRes>> getEntireContributions(
+            @PathVariable Long projectId
+    ) {
+        return ApiResponse.onSuccess(ContributionSuccessCode.CONTRIBUTION_OK, projectContributionService.getEntireContributions(projectId));
+    }
+
+
+
 }

--- a/src/main/java/com/connecteamed/server/domain/contribution/dto/ProjectContributionRes.java
+++ b/src/main/java/com/connecteamed/server/domain/contribution/dto/ProjectContributionRes.java
@@ -1,0 +1,7 @@
+package com.connecteamed.server.domain.contribution.dto;
+
+public record ProjectContributionRes(
+        String date,
+        int count
+) {
+}

--- a/src/main/java/com/connecteamed/server/domain/contribution/dto/ProjectMemberContributionRes.java
+++ b/src/main/java/com/connecteamed/server/domain/contribution/dto/ProjectMemberContributionRes.java
@@ -1,0 +1,9 @@
+package com.connecteamed.server.domain.contribution.dto;
+
+import java.util.List;
+
+public record ProjectMemberContributionRes(
+        Long id,
+        String name,
+        List<DailyContributionRes> contributions
+) {}

--- a/src/main/java/com/connecteamed/server/domain/contribution/repository/ContributionRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/contribution/repository/ContributionRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.List;
 
 public interface ContributionRepository extends JpaRepository<Contribution, Long> {
@@ -33,4 +34,11 @@ public interface ContributionRepository extends JpaRepository<Contribution, Long
         java.sql.Date getDate();
         Integer getCount();
     }
+
+    // 프로젝트 멤버들의 데이터 전체 조회
+    List<Contribution> findAllByUserIdInAndCreatedAtBetween(
+            List<Long> userIds,
+            Instant start,
+            Instant end
+    );
 }

--- a/src/main/java/com/connecteamed/server/domain/contribution/service/ProjectContributionService.java
+++ b/src/main/java/com/connecteamed/server/domain/contribution/service/ProjectContributionService.java
@@ -1,0 +1,136 @@
+package com.connecteamed.server.domain.contribution.service;
+
+import com.connecteamed.server.domain.contribution.code.ContributionErrorCode;
+import com.connecteamed.server.domain.contribution.dto.DailyContributionRes;
+import com.connecteamed.server.domain.contribution.dto.ProjectContributionRes;
+import com.connecteamed.server.domain.contribution.dto.ProjectMemberContributionRes;
+import com.connecteamed.server.domain.contribution.entity.Contribution;
+import com.connecteamed.server.domain.contribution.repository.ContributionRepository;
+import com.connecteamed.server.domain.project.entity.ProjectMember;
+import com.connecteamed.server.domain.project.repository.ProjectMemberRepository;
+import com.connecteamed.server.domain.project.repository.ProjectRepository;
+import com.connecteamed.server.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectContributionService {
+    private final ContributionRepository contributionRepository;
+    private final ProjectMemberRepository projectMemberRepository;
+    private final ProjectRepository projectRepository;
+    private final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Transactional(readOnly = true)
+    public List<ProjectMemberContributionRes> getProjectMemberContributions(Long projectId) {
+
+        if (!projectRepository.existsById(projectId)) {
+            throw new GeneralException(ContributionErrorCode.CONTRIBUTION_PROJECT_NOT_FOUND);
+        }
+
+        // 7*18=126 일의 데이터를 불러오도록 범위 설정
+        LocalDate today = LocalDate.now(KST);
+        LocalDate startDate = today.minusDays(125);
+
+        Instant startInstant = startDate.atStartOfDay(KST).toInstant();
+        Instant endInstant = today.plusDays(1).atStartOfDay(KST).toInstant();
+
+        // 프로젝트 멤버 조회 및 ID 추출
+        List<ProjectMember> projectMembers = projectMemberRepository.findAllByProjectId(projectId);
+        List<Long> userIds = projectMembers.stream()
+                .map(pm -> pm.getMember().getId())
+                .toList();
+
+        // 모든 멤버의 잔디 기록 한번에 조회
+        Map<Long, Map<LocalDate, Long>> allActivityMap = contributionRepository
+                .findAllByUserIdInAndCreatedAtBetween(userIds, startInstant, endInstant).stream()
+                .collect(Collectors.groupingBy(
+                        Contribution::getUserId,
+                        Collectors.groupingBy(
+                                c -> c.getCreatedAt().atZone(KST).toLocalDate(),
+                                Collectors.counting()
+                        )
+                ));
+
+        // 데이터 조립(db에 빈 날짜는 0으로 채우기)
+        return projectMembers.stream().map(pm -> {
+            Long userId = pm.getMember().getId();
+            Map<LocalDate, Long> userActivity = allActivityMap.getOrDefault(userId, Collections.emptyMap());
+
+            List<DailyContributionRes> contributions = new ArrayList<>();
+            for (LocalDate date = startDate; !date.isAfter(today); date = date.plusDays(1)) {
+                int count = userActivity.getOrDefault(date, 0L).intValue();
+                contributions.add(new DailyContributionRes(
+                        date.toString(),
+                        count,
+                        calculateLevel(count)
+                ));
+            }
+
+            return new ProjectMemberContributionRes(
+                    userId,
+                    pm.getMember().getName(),
+                    contributions
+            );
+        }).toList();
+    }
+
+
+
+    @Transactional(readOnly = true)
+    public List<ProjectContributionRes> getEntireContributions(Long projectId) {
+        if (!projectRepository.existsById(projectId)) {
+            throw new GeneralException(ContributionErrorCode.CONTRIBUTION_PROJECT_NOT_FOUND);
+        }
+
+        //2주로 범위 설정
+        LocalDate today = LocalDate.now(KST);
+        LocalDate startDate = today.minusDays(13); // 오늘 포함 14일
+
+        Instant startInstant = startDate.atStartOfDay(KST).toInstant();
+        Instant endInstant = today.plusDays(1).atStartOfDay(KST).toInstant();
+
+        // 프로젝트의 멤버 ID 추출
+        List<Long> userIds = projectMemberRepository.findAllByProjectId(projectId).stream()
+                .map(pm -> pm.getMember().getId())
+                .toList();
+
+        // 잔디 기록 합산
+        Map<LocalDate, Long> teamActivityMap = contributionRepository
+                .findAllByUserIdInAndCreatedAtBetween(userIds, startInstant, endInstant).stream()
+                .collect(Collectors.groupingBy(
+                        c -> c.getCreatedAt().atZone(KST).toLocalDate(),
+                        Collectors.counting()
+                ));
+
+        // 데이터 조립
+        List<ProjectContributionRes> result = new ArrayList<>();
+        for (LocalDate date = startDate; !date.isAfter(today); date = date.plusDays(1)) {
+            int totalCount = teamActivityMap.getOrDefault(date, 0L).intValue();
+            result.add(new ProjectContributionRes(date.toString(), totalCount));
+        }
+
+        return result;
+    }
+
+
+
+
+    private int calculateLevel(int count) {
+        if (count <= 0) return 0;
+        if (count <= 2) return 1;
+        if (count <= 5) return 2;
+        if (count <= 8) return 3;
+        return 4;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,6 +9,8 @@ spring:
       redis:
         host: localhost
         port: 6379
+        password: ${REDIS_PASSWORD}
+
 
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/connecteamed_db}

--- a/src/test/java/com/connecteamed/server/domain/contribution/controller/ContributionControllerTest.java
+++ b/src/test/java/com/connecteamed/server/domain/contribution/controller/ContributionControllerTest.java
@@ -1,0 +1,107 @@
+package com.connecteamed.server.domain.contribution.controller;
+
+import com.connecteamed.server.domain.contribution.code.ContributionErrorCode;
+import com.connecteamed.server.domain.contribution.dto.DailyContributionRes;
+import com.connecteamed.server.domain.contribution.dto.ProjectContributionRes;
+import com.connecteamed.server.domain.contribution.dto.ProjectMemberContributionRes;
+import com.connecteamed.server.domain.contribution.service.ProjectContributionService;
+import com.connecteamed.server.global.apiPayload.exception.GeneralException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ContributionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ProjectContributionService projectContributionService;
+
+    private final Long projectId = 1L;
+
+
+    @Test
+    @WithMockUser(username = "test123")
+    @DisplayName("팀원별 잔디 조회 성공 - 다수 팀원의 데이터 정합성 검증")
+    void getIndividualContributions_MultipleMembers_Success() throws Exception {
+
+        //멤버 1 데이터
+        List<DailyContributionRes> dannyContributions = List.of(
+                new DailyContributionRes("2026-02-10", 5, 2),
+                new DailyContributionRes("2026-02-09", 0, 0)
+        );
+        ProjectMemberContributionRes member1 = new ProjectMemberContributionRes(1L, "test123", dannyContributions);
+        //멤버 2 데이터
+        List<DailyContributionRes> member2Contributions = List.of(
+                new DailyContributionRes("2026-02-10", 10, 4),
+                new DailyContributionRes("2026-02-09", 2, 1)
+        );
+        ProjectMemberContributionRes member2 = new ProjectMemberContributionRes(2L, "Member2", member2Contributions);
+
+        when(projectContributionService.getProjectMemberContributions(projectId))
+                .thenReturn(List.of(member1, member2));
+
+        mockMvc.perform(get("/api/contributions/{projectId}/individual", projectId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data.length()").value(2))
+
+                // 멤버 1 데이터 검증
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].name").value("test123"))
+                .andExpect(jsonPath("$.data[0].contributions[0].count").value(5))
+
+                // 멤버 2 데이터 검증
+                .andExpect(jsonPath("$.data[1].id").value(2))
+                .andExpect(jsonPath("$.data[1].name").value("Member2"))
+                .andExpect(jsonPath("$.data[1].contributions[0].count").value(10))
+                .andExpect(jsonPath("$.data[1].contributions[0].level").value(4));
+    }
+
+    @Test
+    @WithMockUser(username = "test123")
+    @DisplayName("팀 전체 통계 조회 성공")
+    void getEntireContributions_SpringBootTest() throws Exception {
+        List<ProjectContributionRes> mockRes = List.of(new ProjectContributionRes("2026-02-10", 5));
+
+        when(projectContributionService.getEntireContributions(projectId)).thenReturn(mockRes);
+
+        mockMvc.perform(get("/api/contributions/{projectId}/entire", projectId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data[0].count").value(5));
+    }
+
+
+    @Test
+    @WithMockUser(username = "test123")
+    @DisplayName("프로젝트 미존재 시 404 에러 반환")
+    void getContributions_NotFound() throws Exception {
+
+        when(projectContributionService.getProjectMemberContributions(anyLong()))
+                .thenThrow(new GeneralException(ContributionErrorCode.CONTRIBUTION_PROJECT_NOT_FOUND));
+
+        mockMvc.perform(get("/api/contributions/{projectId}/individual", 999L))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value("error"))
+                .andExpect(jsonPath("$.code").value("CONTRIBUTION_PROJECT_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("해당 Id의 프로젝트를 찾을 수 없습니다."));
+    }
+}

--- a/src/test/java/com/connecteamed/server/domain/contribution/controller/ContributionControllerTest.java
+++ b/src/test/java/com/connecteamed/server/domain/contribution/controller/ContributionControllerTest.java
@@ -92,8 +92,23 @@ class ContributionControllerTest {
 
     @Test
     @WithMockUser(username = "test123")
-    @DisplayName("프로젝트 미존재 시 404 에러 반환")
-    void getContributions_NotFound() throws Exception {
+    @DisplayName("팀 전체 업무 통계 조회 - 프로젝트 미존재 시 404 에러 반환")
+    void getTeamContributions_NotFound() throws Exception {
+
+        when(projectContributionService.getEntireContributions(anyLong()))
+                .thenThrow(new GeneralException(ContributionErrorCode.CONTRIBUTION_PROJECT_NOT_FOUND));
+
+        mockMvc.perform(get("/api/contributions/{projectId}/entire", 999L))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value("error"))
+                .andExpect(jsonPath("$.code").value("CONTRIBUTION_PROJECT_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("해당 Id의 프로젝트를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @WithMockUser(username = "test123")
+    @DisplayName("팀원별 업무 통계 조회 - 프로젝트 미존재 시 404 에러 반환")
+    void getIndividualContributions_NotFound() throws Exception {
 
         when(projectContributionService.getProjectMemberContributions(anyLong()))
                 .thenThrow(new GeneralException(ContributionErrorCode.CONTRIBUTION_PROJECT_NOT_FOUND));

--- a/src/test/java/com/connecteamed/server/domain/contribution/service/ProjectContributionServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/contribution/service/ProjectContributionServiceTest.java
@@ -1,0 +1,64 @@
+package com.connecteamed.server.domain.contribution.service;
+
+import com.connecteamed.server.domain.contribution.code.ContributionErrorCode;
+import com.connecteamed.server.domain.contribution.dto.ProjectMemberContributionRes;
+import com.connecteamed.server.domain.contribution.repository.ContributionRepository;
+import com.connecteamed.server.domain.project.repository.ProjectMemberRepository;
+import com.connecteamed.server.domain.project.repository.ProjectRepository;
+import com.connecteamed.server.global.apiPayload.exception.GeneralException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectContributionServiceTest {
+
+    @InjectMocks
+    private ProjectContributionService projectContributionService;
+
+    @Mock
+    private ProjectRepository projectRepository;
+    @Mock
+    private ProjectMemberRepository projectMemberRepository;
+    @Mock
+    private ContributionRepository contributionRepository;
+
+    private final Long projectId = 1L;
+
+    @Test
+    @DisplayName("프로젝트가 존재하지 않으면 에러를 던진다")
+    void getContributions_ProjectNotFound() {
+        // given
+        when(projectRepository.existsById(projectId)).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> projectContributionService.getProjectMemberContributions(projectId))
+                .isInstanceOf(GeneralException.class)
+                .hasFieldOrPropertyWithValue("code", ContributionErrorCode.CONTRIBUTION_PROJECT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("팀원별 잔디 조회 시 데이터 개수가 126개여야 한다")
+    void getProjectMemberContributions_Success() {
+        // given
+        when(projectRepository.existsById(projectId)).thenReturn(true);
+        when(projectMemberRepository.findAllByProjectId(projectId)).thenReturn(Collections.emptyList());
+
+        // when
+        List<ProjectMemberContributionRes> result = projectContributionService.getProjectMemberContributions(projectId);
+
+        // then
+        // 멤버가 0명이어도 리스트는 반환되어야 함
+        assertThat(result).isNotNull();
+    }
+}

--- a/src/test/java/com/connecteamed/server/domain/contribution/service/ProjectContributionServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/contribution/service/ProjectContributionServiceTest.java
@@ -1,8 +1,11 @@
 package com.connecteamed.server.domain.contribution.service;
 
 import com.connecteamed.server.domain.contribution.code.ContributionErrorCode;
+import com.connecteamed.server.domain.contribution.dto.DailyContributionRes;
 import com.connecteamed.server.domain.contribution.dto.ProjectMemberContributionRes;
 import com.connecteamed.server.domain.contribution.repository.ContributionRepository;
+import com.connecteamed.server.domain.member.entity.Member;
+import com.connecteamed.server.domain.project.entity.ProjectMember;
 import com.connecteamed.server.domain.project.repository.ProjectMemberRepository;
 import com.connecteamed.server.domain.project.repository.ProjectRepository;
 import com.connecteamed.server.global.apiPayload.exception.GeneralException;
@@ -13,11 +16,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,17 +54,30 @@ class ProjectContributionServiceTest {
     }
 
     @Test
-    @DisplayName("팀원별 잔디 조회 시 데이터 개수가 126개여야 한다")
-    void getProjectMemberContributions_Success() {
-        // given
-        when(projectRepository.existsById(projectId)).thenReturn(true);
-        when(projectMemberRepository.findAllByProjectId(projectId)).thenReturn(Collections.emptyList());
+    @DisplayName("팀원별 잔디 조회 시 데이터가 없어도 126개의 데이터가 반환되는지 확인")
+    void getProjectMemberContributions_CheckExactly126Days() {
 
-        // when
+        Member mockMember = Member.builder().id(1L).name("test123").build();
+        ProjectMember pm = ProjectMember.builder().member(mockMember).build();
+
+        when(projectRepository.existsById(projectId)).thenReturn(true);
+        when(projectMemberRepository.findAllByProjectId(projectId)).thenReturn(List.of(pm));
+
+        when(contributionRepository.findAllByUserIdInAndCreatedAtBetween(any(), any(), any()))
+                .thenReturn(Collections.emptyList());
+
         List<ProjectMemberContributionRes> result = projectContributionService.getProjectMemberContributions(projectId);
 
-        // then
-        // 멤버가 0명이어도 리스트는 반환되어야 함
-        assertThat(result).isNotNull();
+        assertThat(result).hasSize(1);
+
+        List<DailyContributionRes> contributions = result.get(0).contributions();
+
+        assertThat(contributions).hasSize(126);
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        String expectedStartDate = today.minusDays(125).toString();
+        String expectedEndDate = today.toString();
+
+        assertThat(contributions.get(0).date()).isEqualTo(expectedStartDate);
+        assertThat(contributions.get(125).date()).isEqualTo(expectedEndDate);
     }
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -5,6 +5,12 @@ spring:
   profiles:
     active: test
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: ${REDIS_PASSWORD}
+
   datasource:
     url: jdbc:h2:mem:testdb;MODE=PostgreSQL
     username: sa


### PR DESCRIPTION
## 📌 PR 요약
-  팀 업무 통계 탭UI에 필요한 팀 전체/팀원별 업무 통계 조회 API를 구현했습니다. dto는 세정님이 작성하신 잔디 API을 참고하여 통일성 있게 작성하였습니다.

## 🔧 변경 사항


## 📋 작업 상세 내용
- [x] 팀 전체 업무 통계 조회 API 구현
- [x] 팀원 별 업무 통계 조회 API 구현
- [x] testcode 작성

## 🔗 관련 이슈
- 관련있는 이슈 번호(#000)을 작성합니다.
- closed #79 

## 📝 기타