### PR TITLE
[FIX] 다중 컬렉션 Fetch Join 시 발생하는 500 에러 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # Connected-BE
 
+## 💡 Project Overview
+
+Connecteamed는 복잡한 설정 과정을 최소화하여 누구나 쉽게 팀 프로젝트를 시작할 수 있게 돕고,
+업무 과정에서 쌓인 데이터를 바탕으로 프로젝트의 시작부터 회고까지의 흐름을 관리해주는 팀 협업 관리 플랫폼입니다.
+
+## 👥 Contributors
+
+|                                                           **애나/김민선**                                                           |                                                              **정/김세정**                                                               |                                                               **현/류동현**                                                                |                                                                **막더/박상민**                                                                |
+|:------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------------------------------------:|:--------------------------------------------------------------------------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------------------------------------------------:|
+| [<img src="https://avatars.githubusercontent.com/u/122611609?v=4" height=150 width=150> <br/> sunnyanna0](https://github.com/sunnyanna0) | [<img src="https://avatars.githubusercontent.com/u/203520708?v=4" height=150 width=150> <br/> sejeong223](https://github.com/sejeong223) | [<img src="https://avatars.githubusercontent.com/u/201970138?v=4" height=150 width=150> <br/> fbehdgus906](https://github.com/fbehdgus906) | [<img src="https://avatars.githubusercontent.com/u/88922405?v=4" height=150 width=150> <br/> sm010422](https://github.com/sm010422) |
+
+
+## 🛠️ Tech Stacks
+
+
+
+
 ## 📢 Connected-BE API Server - Convention & Structure
 
 ## Git 규칙 (Commit Convention)

--- a/src/main/java/com/connecteamed/server/domain/project/entity/ProjectMember.java
+++ b/src/main/java/com/connecteamed/server/domain/project/entity/ProjectMember.java
@@ -9,7 +9,9 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Builder
@@ -40,11 +42,11 @@ public class ProjectMember extends BaseEntity {
 
     @Builder.Default
     @OneToMany(mappedBy = "projectMember", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ProjectMemberRole> roles = new ArrayList<>();
+    private Set<ProjectMemberRole> roles = new LinkedHashSet<>();
 
     @Builder.Default
     @OneToMany(mappedBy = "projectMember")
-    private List<TaskAssignee> taskAssignees = new ArrayList<>();
+    private Set<TaskAssignee> taskAssignees = new LinkedHashSet<>();
 
     public List<Task> getTasks() {
         return this.taskAssignees.stream()


### PR DESCRIPTION
## 📌 PR 요약
- ProjectMember 엔티티의 다중 컬렉션 페치 조인 시 발생하는 MultipleBagFetchException을 해결하고, AI 회고 조회 API의 500 에러를 수정

## 🔧 변경 사항
- ProjectMember 클래스의 roles와 taskAssignees 필드 타입을 List에서 Set(LinkedHashSet)으로 변경

## 📋 작업 상세 내용
- [x] ProjectMember 엔티티 내 roles, taskAssignees 필드 타입 수정 (List -> Set)
- [x] 순서 유지를 위해 LinkedHashSet으로 초기화 구현

## 🔗 관련 이슈
- closed #84 
