### PR TITLE
[Fix] AI 회고 수정/삭제 시 본인 권한 인증 실패 문제 해결

### DIFF
--- a/src/main/java/com/connecteamed/server/domain/retrospective/controller/RetrospectiveController.java
+++ b/src/main/java/com/connecteamed/server/domain/retrospective/controller/RetrospectiveController.java
@@ -46,9 +46,10 @@ public class RetrospectiveController {
     @GetMapping("/{retrospectiveId}")
     public ApiResponse<RetrospectiveDetailRes> getRetrospectiveDetail(
             @PathVariable Long projectId,
-            @PathVariable Long retrospectiveId
+            @PathVariable Long retrospectiveId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
-        RetrospectiveDetailRes response = retrospectiveService.getRetrospectiveDetail(projectId, retrospectiveId);
+        RetrospectiveDetailRes response = retrospectiveService.getRetrospectiveDetail(customUserDetails.member().getId(), projectId, retrospectiveId);
         return ApiResponse.onSuccess(GeneralSuccessCode._OK, response);
     }
 

--- a/src/main/java/com/connecteamed/server/domain/retrospective/entity/RetrospectiveTask.java
+++ b/src/main/java/com/connecteamed/server/domain/retrospective/entity/RetrospectiveTask.java
@@ -29,6 +29,9 @@ public class RetrospectiveTask extends BaseEntity {
     @JoinColumn(name = "task_id", nullable = false)
     private Task task;
 
+    @Column(name = "deleted_at")
+    private java.time.Instant deletedAt;
+
     public void setAiRetrospective(AiRetrospective aiRetrospective) {
         this.aiRetrospective = aiRetrospective;
     }

--- a/src/main/java/com/connecteamed/server/domain/retrospective/service/RetrospectiveService.java
+++ b/src/main/java/com/connecteamed/server/domain/retrospective/service/RetrospectiveService.java
@@ -41,8 +41,8 @@ public class RetrospectiveService {
         Project project = projectRepository.findByIdWithDetails(projectId)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND));
 
-        ProjectMember writer = projectMemberRepository.findById(memberId)
-                .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND));
+        ProjectMember writer = projectMemberRepository.findByProject_IdAndMember_Id(projectId, memberId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.FORBIDDEN));
 
         List<Task> selectedTasks = taskRepository.findAllById(request.taskIds());
 
@@ -97,9 +97,13 @@ public class RetrospectiveService {
     }
 
     // ai 회고 상세 조회
-    public RetrospectiveDetailRes getRetrospectiveDetail(Long projectId, Long retrospectiveId) {
+    public RetrospectiveDetailRes getRetrospectiveDetail(Long projectId, Long retrospectiveId, Long memberId) {
         AiRetrospective retrospective = aiRetrospectiveRepository.findByIdAndProjectId(retrospectiveId, projectId)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND));
+
+        if (!retrospective.getWriter().getMember().getId().equals(memberId)) {
+            throw new GeneralException(GeneralErrorCode.FORBIDDEN);
+        }
 
         return new RetrospectiveDetailRes(
                 retrospective.getId(),
@@ -130,6 +134,9 @@ public class RetrospectiveService {
     public void updateRetrospective(Long memberId, Long projectId, Long retrospectiveId, RetrospectiveUpdateReq request) {
         AiRetrospective retrospective = aiRetrospectiveRepository.findByIdAndProjectId(retrospectiveId, projectId)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND));
+
+        System.out.println("로그인한 유저 ID (memberId): " + memberId);
+        System.out.println("회고 작성자 유저 ID: " + retrospective.getWriter().getMember().getId());
 
         if (!retrospective.getWriter().getMember().getId().equals(memberId)) {
             throw new GeneralException(GeneralErrorCode.FORBIDDEN);

--- a/src/test/java/com/connecteamed/server/domain/retrospective/service/RetrospectiveServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/retrospective/service/RetrospectiveServiceTest.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 @ExtendWith(MockitoExtension.class)
@@ -80,7 +81,7 @@ public class RetrospectiveServiceTest {
 
         given(project.getProjectMembers()).willReturn(List.of(writer));
         given(writer.getId()).willReturn(memberId);
-        given(writer.getRoles()).willReturn(List.of());
+        given(writer.getRoles()).willReturn(Set.of());
 
         given(projectRepository.findByIdWithDetails(projectId)).willReturn(Optional.of(project));
         given(projectMemberRepository.findById(memberId)).willReturn(Optional.of(writer));


### PR DESCRIPTION
## 📌 PR 요약
- AI 회고 수정 및 삭제 시 발생하던 권한 인증 오류 문제를 해결하고, 관련 서비스 로직 및 테스트 코드를 보완

## 🔧 변경 사항
- 유저 고유 ID(Member ID)와 프로젝트 참여자 식별자(ProjectMember ID)를 혼동하여 비교하던 로직을 수정하여, 실제 유저 PK를 기준으로 본인 여부를 확인하도록 변경
- 엔티티 필드 타입(Set)과 테스트 코드 내 Mocking 타입(List) 불일치로 인한 빌드 오류를 해결

## 📋 작업 상세 내용
- [x] RetrospectiveService 내 수정/삭제 시 유저 ID 기반 권한 체크 로직 적용
- [x] RetrospectiveServiceTest 컴파일 에러 수정 (Set.of() 적용)

## 🔗 관련 이슈
- closed #88