### PR TITLE
[Fix] 회고 상세 조회 로직 원복

### DIFF
--- a/src/main/java/com/connecteamed/server/domain/retrospective/controller/RetrospectiveController.java
+++ b/src/main/java/com/connecteamed/server/domain/retrospective/controller/RetrospectiveController.java
@@ -46,10 +46,9 @@ public class RetrospectiveController {
     @GetMapping("/{retrospectiveId}")
     public ApiResponse<RetrospectiveDetailRes> getRetrospectiveDetail(
             @PathVariable Long projectId,
-            @PathVariable Long retrospectiveId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails customUserDetails
+            @PathVariable Long retrospectiveId
     ) {
-        RetrospectiveDetailRes response = retrospectiveService.getRetrospectiveDetail(customUserDetails.member().getId(), projectId, retrospectiveId);
+        RetrospectiveDetailRes response = retrospectiveService.getRetrospectiveDetail(projectId, retrospectiveId);
         return ApiResponse.onSuccess(GeneralSuccessCode._OK, response);
     }
 

--- a/src/main/java/com/connecteamed/server/domain/retrospective/service/RetrospectiveService.java
+++ b/src/main/java/com/connecteamed/server/domain/retrospective/service/RetrospectiveService.java
@@ -97,13 +97,9 @@ public class RetrospectiveService {
     }
 
     // ai 회고 상세 조회
-    public RetrospectiveDetailRes getRetrospectiveDetail(Long projectId, Long retrospectiveId, Long memberId) {
+    public RetrospectiveDetailRes getRetrospectiveDetail(Long projectId, Long retrospectiveId) {
         AiRetrospective retrospective = aiRetrospectiveRepository.findByIdAndProjectId(retrospectiveId, projectId)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND));
-
-        if (!retrospective.getWriter().getMember().getId().equals(memberId)) {
-            throw new GeneralException(GeneralErrorCode.FORBIDDEN);
-        }
 
         return new RetrospectiveDetailRes(
                 retrospective.getId(),


### PR DESCRIPTION
## 📌 PR 요약
- 회고 상세 조회 로직을 원복시켰습니다.

## 🔧 변경 사항
- 유저 ID 값만을 추적하도록 변경한 로직에서 오류가 발생해 customUserDetails 객체를 통째로 전달하도록 수정했습니다.

## 🔗 관련 이슈
- closed #90 
