### PR TITLE
[Fix] 팀 업무 통계(contribution) 조회 오류 수정

### DIFF
--- a/src/main/java/com/connecteamed/server/domain/contribution/entity/Contribution.java
+++ b/src/main/java/com/connecteamed/server/domain/contribution/entity/Contribution.java
@@ -21,6 +21,9 @@ public class Contribution {
     @Column(nullable = false)
     private Long userId;
 
+    @Column(nullable = false)
+    private Long projectId;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ContributionAction actionType;
@@ -32,8 +35,9 @@ public class Contribution {
     private Instant createdAt;
 
     @Builder
-    public Contribution(Long userId, ContributionAction actionType, Long targetId) {
+    public Contribution(Long userId, Long projectId, ContributionAction actionType, Long targetId) {
         this.userId = userId;
+        this.projectId = projectId;
         this.actionType = actionType;
         this.targetId = targetId;
         this.createdAt = Instant.now();

--- a/src/main/java/com/connecteamed/server/domain/contribution/repository/ContributionRepository.java
+++ b/src/main/java/com/connecteamed/server/domain/contribution/repository/ContributionRepository.java
@@ -36,9 +36,12 @@ public interface ContributionRepository extends JpaRepository<Contribution, Long
     }
 
     // 프로젝트 멤버들의 데이터 전체 조회
-    List<Contribution> findAllByUserIdInAndCreatedAtBetween(
+    List<Contribution> findAllByProjectIdAndUserIdInAndCreatedAtBetween(
+            Long projectId,
             List<Long> userIds,
             Instant start,
             Instant end
     );
+    //프로젝트 전체 업무 통계 데이터 조회
+    List<Contribution> findAllByProjectIdAndCreatedAtBetween(Long projectId, Instant start, Instant end);
 }

--- a/src/main/java/com/connecteamed/server/domain/contribution/service/ContributionService.java
+++ b/src/main/java/com/connecteamed/server/domain/contribution/service/ContributionService.java
@@ -26,7 +26,7 @@ public class ContributionService {
     private final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     @Transactional
-    public ContributionRes recordContribution(Long userId, ContributionReq request) {
+    public ContributionRes recordContribution(Long userId, Long projectId, ContributionReq request) {
         // 중복 체크
         boolean alreadyExists = contributionRepository.existsByUserIdAndActionTypeAndTargetId(
                 userId, request.actionType(), request.targetId());
@@ -34,6 +34,7 @@ public class ContributionService {
         if (!alreadyExists) {
             contributionRepository.save(Contribution.builder()
                     .userId(userId)
+                    .projectId(projectId)
                     .actionType(request.actionType())
                     .targetId(request.targetId())
                     .build());

--- a/src/main/java/com/connecteamed/server/domain/contribution/service/ProjectContributionService.java
+++ b/src/main/java/com/connecteamed/server/domain/contribution/service/ProjectContributionService.java
@@ -53,7 +53,7 @@ public class ProjectContributionService {
 
         // 모든 멤버의 잔디 기록 한번에 조회
         Map<Long, Map<LocalDate, Long>> allActivityMap = contributionRepository
-                .findAllByUserIdInAndCreatedAtBetween(userIds, startInstant, endInstant).stream()
+                .findAllByProjectIdAndUserIdInAndCreatedAtBetween(projectId,userIds, startInstant, endInstant).stream()
                 .collect(Collectors.groupingBy(
                         Contribution::getUserId,
                         Collectors.groupingBy(
@@ -99,15 +99,11 @@ public class ProjectContributionService {
 
         Instant startInstant = startDate.atStartOfDay(KST).toInstant();
         Instant endInstant = today.plusDays(1).atStartOfDay(KST).toInstant();
-
-        // 프로젝트의 멤버 ID 추출
-        List<Long> userIds = projectMemberRepository.findAllByProjectId(projectId).stream()
-                .map(pm -> pm.getMember().getId())
-                .toList();
+        
 
         // 잔디 기록 합산
         Map<LocalDate, Long> teamActivityMap = contributionRepository
-                .findAllByUserIdInAndCreatedAtBetween(userIds, startInstant, endInstant).stream()
+                .findAllByProjectIdAndCreatedAtBetween(projectId, startInstant, endInstant).stream()
                 .collect(Collectors.groupingBy(
                         c -> c.getCreatedAt().atZone(KST).toLocalDate(),
                         Collectors.counting()

--- a/src/main/java/com/connecteamed/server/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/document/service/DocumentServiceImpl.java
@@ -145,7 +145,7 @@ public class DocumentServiceImpl implements DocumentService {
         Document d = Document.createText(projectRef, projectMember, req.title());
         documentRepository.save(d);
 
-        contributionService.recordContribution(projectMember.getMember().getId(),
+        contributionService.recordContribution(projectMember.getMember().getId(), projectId,
                 new ContributionReq(ContributionAction.DOCUMENT_CREATE, d.getId()));
 
         return new DocumentCreateRes(d.getId(), d.getCreatedAt().toString());
@@ -172,7 +172,7 @@ public class DocumentServiceImpl implements DocumentService {
         Document d = Document.createFile(projectRef, projectMember, title, type, fileUrl);
         documentRepository.save(d);
 
-        contributionService.recordContribution(projectMember.getMember().getId(),
+        contributionService.recordContribution(projectMember.getMember().getId(), projectId,
                 new ContributionReq(ContributionAction.DOCUMENT_CREATE, d.getId()));
 
         return new DocumentUploadRes(d.getId(), title, d.getCreatedAt().toString());
@@ -191,7 +191,7 @@ public class DocumentServiceImpl implements DocumentService {
 
         d.updateText(req.title(), req.content());
 
-        contributionService.recordContribution(d.getProjectMember().getMember().getId(),
+        contributionService.recordContribution(d.getProjectMember().getMember().getId(), d.getProject().getId(),
                 new ContributionReq(ContributionAction.DOCUMENT_UPDATE, d.getId()));
     }
 

--- a/src/main/java/com/connecteamed/server/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/service/MeetingService.java
@@ -78,7 +78,7 @@ public class MeetingService {
         Meeting savedMeeting = meetingRepository.save(meeting);
 
         Long userId = securityUtil.getCurrentMemberId();
-        contributionService.recordContribution(userId,
+        contributionService.recordContribution(userId, projectId,
                 new ContributionReq(ContributionAction.MEETING_CREATE, savedMeeting.getId()));
 
         return new MeetingCreateRes(savedMeeting.getId(), savedMeeting.getCreatedAt());
@@ -135,7 +135,7 @@ public class MeetingService {
             });
         }
 
-        contributionService.recordContribution(userId,
+        contributionService.recordContribution(userId, meeting.getProject().getId(),
                 new ContributionReq(ContributionAction.MEETING_UPDATE, meeting.getId()));
         return getMeeting(meetingId);
     }

--- a/src/main/java/com/connecteamed/server/domain/project/service/ProjectMemberServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/project/service/ProjectMemberServiceImpl.java
@@ -116,7 +116,7 @@ public class ProjectMemberServiceImpl implements ProjectMemberService {
                 );
             }
         }
-        contributionService.recordContribution(getCurrentUserId(),
+        contributionService.recordContribution(getCurrentUserId(), projectId,
                 new ContributionReq(ContributionAction.PROJECT_UPDATE, projectMemberId));
 
         return toRes(pm);

--- a/src/main/java/com/connecteamed/server/domain/project/service/ProjectService.java
+++ b/src/main/java/com/connecteamed/server/domain/project/service/ProjectService.java
@@ -134,7 +134,7 @@ public class ProjectService {
                 log.debug("[ProjectService] Required role registered: {}", roleName);
             }
         }
-        contributionService.recordContribution(owner.getId(),
+        contributionService.recordContribution(owner.getId(), savedProject.getId(),
                 new ContributionReq(ContributionAction.PROJECT_CREATE, savedProject.getId()));
 
         // 4. 응답 반환
@@ -231,7 +231,7 @@ public class ProjectService {
                 log.debug("[ProjectService] Required role registered: {}", roleName);
             }
         }
-        contributionService.recordContribution(getCurrentUserId(),
+        contributionService.recordContribution(getCurrentUserId(), projectId,
                 new ContributionReq(ContributionAction.PROJECT_UPDATE, project.getId()));
 
         // 6. 응답 반환

--- a/src/main/java/com/connecteamed/server/domain/retrospective/service/RetrospectiveService.java
+++ b/src/main/java/com/connecteamed/server/domain/retrospective/service/RetrospectiveService.java
@@ -90,7 +90,7 @@ public class RetrospectiveService {
                 otherTasks
         );
 
-        contributionService.recordContribution(writer.getMember().getId(),
+        contributionService.recordContribution(writer.getMember().getId(), projectId,
                 new ContributionReq(ContributionAction.RETROSPECTIVE_CREATE, saved.getId()));
 
         return new RetrospectiveCreateRes(saved.getId(), saved.getTitle());
@@ -136,7 +136,7 @@ public class RetrospectiveService {
         }
         retrospective.update(request.title(), request.projectResult());
 
-        contributionService.recordContribution(memberId,
+        contributionService.recordContribution(memberId,projectId,
                 new ContributionReq(ContributionAction.RETROSPECTIVE_UPDATE, retrospective.getId()));
     }
 

--- a/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
@@ -111,7 +111,7 @@ public class CompletedTaskService {
         TaskStatus oldStatus = task.getStatus();
         task.updateStatus(taskStatus);
 
-        contributionService.recordContribution(currentMemberId,
+        contributionService.recordContribution(currentMemberId, task.getProject().getId(),
                 new ContributionReq(ContributionAction.COMPLETED_TASK_UPDATE, taskId));
 
         // 완료한 업무 상태 변경 시 알림 발송
@@ -195,7 +195,7 @@ public class CompletedTaskService {
                 .orElseGet(() -> createNewNote(task, currentMemberId));
         note.updateContent(req.noteContent());
 
-        contributionService.recordContribution(currentMemberId,
+        contributionService.recordContribution(currentMemberId, task.getProject().getId(),
                 new ContributionReq(ContributionAction.COMPLETED_TASK_UPDATE, taskId));
 
         // 완료한 업무 정보 수정 시 알림 발송

--- a/src/main/java/com/connecteamed/server/domain/task/service/TaskServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/TaskServiceImpl.java
@@ -74,7 +74,7 @@ public class TaskServiceImpl implements TaskService {
         // 알림: 업무 태그
         notificationHelper.sendToAllAssignees(saved, NotificationCategory.TASK_TAGGED);
 
-        contributionService.recordContribution(getCurrentUserId(),
+        contributionService.recordContribution(getCurrentUserId(), projectId,
                 new ContributionReq(ContributionAction.TASK_CREATE, saved.getId()));
 
         return saved.getId();
@@ -148,7 +148,7 @@ public class TaskServiceImpl implements TaskService {
         TaskStatus oldStatus = task.getStatus();
         task.changeStatus(req.status());
 
-        contributionService.recordContribution(currentMemberId,
+        contributionService.recordContribution(currentMemberId, task.getProject().getId(),
                 new ContributionReq(ContributionAction.TASK_UPDATE, taskId));
 
         // 알림: 다시 진행 중 or 완료
@@ -173,7 +173,7 @@ public class TaskServiceImpl implements TaskService {
 
         task.changeSchedule(req.startDate(), req.dueDate());
 
-        contributionService.recordContribution(getCurrentUserId(),
+        contributionService.recordContribution(getCurrentUserId(), task.getProject().getId(),
                 new ContributionReq(ContributionAction.TASK_UPDATE, taskId));
 
         // 알림: 업무 내용 수정
@@ -194,7 +194,7 @@ public class TaskServiceImpl implements TaskService {
         List<Long> assigneeIds = req.assigneeProjectMemberIds() == null ? List.of() : req.assigneeProjectMemberIds();
         attachAssignees(task, projectId, assigneeIds);
 
-        contributionService.recordContribution(getCurrentUserId(),
+        contributionService.recordContribution(getCurrentUserId(), projectId,
                 new ContributionReq(ContributionAction.TASK_UPDATE, taskId));
 
         // 알림: 새로 태그된 사람들에게 알림 발송

--- a/src/test/java/com/connecteamed/server/domain/contribution/service/ContributionServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/contribution/service/ContributionServiceTest.java
@@ -33,6 +33,7 @@ public class ContributionServiceTest {
     void recordContribution_success() {
         // given
         Long userId = 1L;
+        Long projectId = 1L;
         ContributionReq request = new ContributionReq(ContributionAction.TASK_CREATE, 100L);
 
         given(contributionRepository.existsByUserIdAndActionTypeAndTargetId(userId, request.actionType(), request.targetId()))
@@ -41,7 +42,7 @@ public class ContributionServiceTest {
                 .willReturn(1);
 
         // when
-        ContributionRes result = contributionService.recordContribution(userId, request);
+        ContributionRes result = contributionService.recordContribution(userId, projectId, request);
 
         // then
         assertThat(result.isIncremented()).isTrue();
@@ -55,6 +56,7 @@ public class ContributionServiceTest {
     void recordContribution_duplicate() {
         // given
         Long userId = 1L;
+        Long projectId = 1L;
         ContributionReq request = new ContributionReq(ContributionAction.TASK_CREATE, 100L);
 
         given(contributionRepository.existsByUserIdAndActionTypeAndTargetId(userId, request.actionType(), request.targetId()))
@@ -63,7 +65,7 @@ public class ContributionServiceTest {
                 .willReturn(5);
 
         // when
-        ContributionRes result = contributionService.recordContribution(userId, request);
+        ContributionRes result = contributionService.recordContribution(userId, projectId, request);
 
         // then
         assertThat(result.isIncremented()).isFalse();
@@ -85,6 +87,7 @@ public class ContributionServiceTest {
 
     private int getLevelFromCount(int count) {
         Long userId = 1L;
+        Long projectId = 1L;
         ContributionReq req = new ContributionReq(ContributionAction.TASK_CREATE, 999L);
 
         lenient().when(contributionRepository.existsByUserIdAndActionTypeAndTargetId(anyLong(), any(), anyLong()))
@@ -92,6 +95,6 @@ public class ContributionServiceTest {
         lenient().when(contributionRepository.countTodayActivities(eq(userId), any(Instant.class), any(Instant.class)))
                 .thenReturn(count);
 
-        return contributionService.recordContribution(userId, req).currentLevel();
+        return contributionService.recordContribution(userId, projectId, req).currentLevel();
     }
 }

--- a/src/test/java/com/connecteamed/server/domain/contribution/service/ProjectContributionServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/contribution/service/ProjectContributionServiceTest.java
@@ -63,7 +63,7 @@ class ProjectContributionServiceTest {
         when(projectRepository.existsById(projectId)).thenReturn(true);
         when(projectMemberRepository.findAllByProjectId(projectId)).thenReturn(List.of(pm));
 
-        when(contributionRepository.findAllByUserIdInAndCreatedAtBetween(any(), any(), any()))
+        when(contributionRepository.findAllByProjectIdAndUserIdInAndCreatedAtBetween(any(),any(), any(), any()))
                 .thenReturn(Collections.emptyList());
 
         List<ProjectMemberContributionRes> result = projectContributionService.getProjectMemberContributions(projectId);

--- a/src/test/java/com/connecteamed/server/domain/document/service/DocumentServiceImplTest.java
+++ b/src/test/java/com/connecteamed/server/domain/document/service/DocumentServiceImplTest.java
@@ -84,6 +84,7 @@ class DocumentServiceImplTest {
         // ContributionService가 DOCUMENT_CREATE 타입으로 호출되었는가?
         verify(contributionService, times(1)).recordContribution(
                 eq(memberId),
+                eq(projectId),
                 argThat(req -> req.actionType() == ContributionAction.DOCUMENT_CREATE
                         && req.targetId().equals(savedDocumentId))
         );
@@ -101,7 +102,7 @@ class DocumentServiceImplTest {
 
         then(s3StorageService).shouldHaveNoInteractions();
         then(documentRepository).shouldHaveNoInteractions();
-        verify(contributionService, never()).recordContribution(any(), any());
+        verify(contributionService, never()).recordContribution(any(),any(), any());
     }
 
     @Test
@@ -145,7 +146,7 @@ class DocumentServiceImplTest {
 
         then(s3StorageService).shouldHaveNoInteractions();
 
-        verify(contributionService, never()).recordContribution(any(), any());
+        verify(contributionService, never()).recordContribution(any(), any(), any());
     }
 
     @Test
@@ -207,7 +208,7 @@ class DocumentServiceImplTest {
         documentService.updateText(documentId, req);
 
         then(d).should().updateText("수정제목", "수정내용");
-        verify(contributionService).recordContribution(eq(memberId), any());
+        verify(contributionService).recordContribution(any(), eq(memberId), any());
     }
 
     @Test

--- a/src/test/java/com/connecteamed/server/domain/document/service/DocumentServiceImplTest.java
+++ b/src/test/java/com/connecteamed/server/domain/document/service/DocumentServiceImplTest.java
@@ -208,7 +208,7 @@ class DocumentServiceImplTest {
         documentService.updateText(documentId, req);
 
         then(d).should().updateText("수정제목", "수정내용");
-        verify(contributionService).recordContribution(any(), eq(memberId), any());
+        verify(contributionService).recordContribution(eq(memberId), any(), any());
     }
 
     @Test

--- a/src/test/java/com/connecteamed/server/domain/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/meeting/service/MeetingServiceTest.java
@@ -97,7 +97,7 @@ class MeetingServiceTest {
         // then
         then(meetingRepository).should().save(any(Meeting.class));
         assertThat(res.meetingId()).isEqualTo(100L);
-        verify(contributionService).recordContribution(eq(userId), any(ContributionReq.class));
+        verify(contributionService).recordContribution(eq(userId), eq(projectId), any(ContributionReq.class));
     }
 
     @Test
@@ -130,7 +130,7 @@ class MeetingServiceTest {
 
         // then
         assertThat(existingMeeting.getTitle()).isEqualTo("수정 제목");
-        verify(contributionService).recordContribution(eq(userId), any(ContributionReq.class));
+        verify(contributionService).recordContribution(eq(userId), eq(projectId), any(ContributionReq.class));
     }
 
     @Test
@@ -187,7 +187,7 @@ class MeetingServiceTest {
                 .isInstanceOf(GeneralException.class)
                 .hasFieldOrPropertyWithValue("code", GeneralErrorCode.NOT_FOUND);
 
-        verify(contributionService, never()).recordContribution(any(), any());
+        verify(contributionService, never()).recordContribution(any(), any(), any());
     }
 
     @Test

--- a/src/test/java/com/connecteamed/server/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/project/service/ProjectServiceTest.java
@@ -158,7 +158,7 @@ class ProjectServiceTest {
         verify(projectRequiredRoleRepository, times(3)).save(any(ProjectRequiredRole.class));
 
         ArgumentCaptor<ContributionReq> contribCaptor = ArgumentCaptor.forClass(ContributionReq.class);
-        verify(contributionService).recordContribution(eq(testMember.getId()), contribCaptor.capture());
+        verify(contributionService).recordContribution(eq(testMember.getId()), eq(testProject.getId()), contribCaptor.capture());
 
         assertThat(contribCaptor.getValue().actionType()).isEqualTo(ContributionAction.PROJECT_CREATE);
         assertThat(contribCaptor.getValue().targetId()).isEqualTo(testProject.getId());
@@ -310,7 +310,7 @@ class ProjectServiceTest {
         assertEquals(1L, response.getProjectId());
         verify(projectRequiredRoleRepository, times(1)).deleteAll(any());
         verify(projectRequiredRoleRepository, times(2)).save(any(ProjectRequiredRole.class));
-        verify(contributionService).recordContribution(eq(testMember.getId()),
+        verify(contributionService).recordContribution(eq(testMember.getId()), eq(1L),
                 argThat(c -> c.actionType() == ContributionAction.PROJECT_UPDATE));
     }
 

--- a/src/test/java/com/connecteamed/server/domain/retrospective/service/RetrospectiveServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/retrospective/service/RetrospectiveServiceTest.java
@@ -96,7 +96,7 @@ public class RetrospectiveServiceTest {
         verify(aiRetrospectiveRepository, times(1)).save(any());
 
         ArgumentCaptor<ContributionReq> contribCaptor = ArgumentCaptor.forClass(ContributionReq.class);
-        verify(contributionService).recordContribution(eq(realMemberId), contribCaptor.capture());
+        verify(contributionService).recordContribution(eq(realMemberId), eq(projectId), contribCaptor.capture());
         assertThat(contribCaptor.getValue().actionType()).isEqualTo(ContributionAction.RETROSPECTIVE_CREATE);
         assertThat(contribCaptor.getValue().targetId()).isEqualTo(mockRetrospectiveId);
 
@@ -129,7 +129,7 @@ public class RetrospectiveServiceTest {
 
         // then
         verify(retrospective).update(anyString(), anyString());
-        verify(contributionService).recordContribution(eq(memberId), argThat(c ->
+        verify(contributionService).recordContribution(eq(memberId), eq(projectId), argThat(c ->
                 c.actionType() == ContributionAction.RETROSPECTIVE_UPDATE &&
                         retrospectiveId.equals(c.targetId())
         ));

--- a/src/test/java/com/connecteamed/server/domain/task/service/CompletedTaskServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/task/service/CompletedTaskServiceTest.java
@@ -97,7 +97,7 @@ class CompletedTaskServiceTest {
             completedTaskService.updateCompletedTaskStatus(taskId, TaskStatus.IN_PROGRESS);
 
             // then
-            verify(contributionService).recordContribution(eq(memberId), any());
+            verify(contributionService).recordContribution(eq(memberId),any(), any());
             verify(notificationHelper, times(1)).sendToOthers(eq(task), eq(NotificationCategory.TASK_RESTARTED));
         }
     }
@@ -159,7 +159,7 @@ class CompletedTaskServiceTest {
             verify(taskAssigneeRepository, times(1)).saveAll(anyList());
             verify(mockNote).updateContent(req.noteContent());
 
-            verify(contributionService).recordContribution(eq(memberId), any());
+            verify(contributionService).recordContribution(eq(memberId),any(), any());
             verify(notificationHelper, times(1)).sendToOthers(eq(task), eq(NotificationCategory.TASK_MODIFIED));
 
             assertThat(result).isNotNull();
@@ -205,7 +205,7 @@ class CompletedTaskServiceTest {
         // then
         assertThat(result.noteContent()).isEqualTo("나의 회고록");
         verify(taskNoteRepository, times(1)).findByTaskIdAndTaskAssignee_ProjectMember_Id(taskId, memberId);
-        verify(contributionService, never()).recordContribution(any(), any());
+        verify(contributionService, never()).recordContribution(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## 📌 PR 요약
- 기존 로직에서는 프로젝트에 속한 contribution만을 끌어오는 것이 아닌 프로젝트 팀원 개인의 모든 contribution 합을 팀 업무 통계로 산출해 내는 오류가 있었습니다. 이를 해결하기 위한 작업을 진행하는 pr입니다

## 🔧 변경 사항
-contributions entity에 project_id 컬럼을 추가하고 프로젝트면 contribution을 조회할 때  project_id를 함께 이용하여 조회하도록 로직 수정하였습니다
## 📋 작업 상세 내용
- [x] project_id 컬럼 추가 및 repository계층 코드 수정
- [x] 팀 contribution 조회 service 로직 수정
- [x] contribution 기록시 매개변수에 projectId 추가
- [x] 테스트 코드 수정

## 🔗 관련 이슈
- 관련있는 이슈 번호(#000)을 작성합니다.
- closed #79 

## 📝 기타
