### PR TITLE
[Fix] 잔디 누락 오류 수정

### DIFF
--- a/src/main/java/com/connecteamed/server/domain/contribution/controller/ContributionController.java
+++ b/src/main/java/com/connecteamed/server/domain/contribution/controller/ContributionController.java
@@ -29,10 +29,10 @@ public class ContributionController {
     @GetMapping("/calendar")
     @Operation(summary = "연간 잔디 조회", description = "특정 연도의 1월 1일부터 12월 31일까지의 모든 잔디 데이터를 조회합니다.")
     public ApiResponse<CalendarContributionRes> getCalendar(
-            @AuthenticationPrincipal Long userId,
+            @RequestParam(name = "projectId") Long projectId,
             @RequestParam(name = "year") int year
     ) {
-        return ApiResponse.onSuccess(GeneralSuccessCode._OK, contributionService.getCalendar(userId, year));
+        return ApiResponse.onSuccess(GeneralSuccessCode._OK, contributionService.getCalendar(projectId, year));
     }
 
 

--- a/src/main/java/com/connecteamed/server/domain/contribution/dto/ContributionRes.java
+++ b/src/main/java/com/connecteamed/server/domain/contribution/dto/ContributionRes.java
@@ -4,7 +4,7 @@ import com.connecteamed.server.domain.contribution.enums.ContributionAction;
 
 public record ContributionRes (
         ContributionAction actionType,
-        int totalCount,
+        int todayCount,
         int currentLevel,
         boolean isIncremented
 ) {}

--- a/src/main/java/com/connecteamed/server/domain/contribution/service/ContributionService.java
+++ b/src/main/java/com/connecteamed/server/domain/contribution/service/ContributionService.java
@@ -6,6 +6,11 @@ import com.connecteamed.server.domain.contribution.dto.ContributionRes;
 import com.connecteamed.server.domain.contribution.dto.DailyContributionRes;
 import com.connecteamed.server.domain.contribution.entity.Contribution;
 import com.connecteamed.server.domain.contribution.repository.ContributionRepository;
+import com.connecteamed.server.domain.project.entity.ProjectMember;
+import com.connecteamed.server.domain.project.repository.ProjectMemberRepository;
+import com.connecteamed.server.global.apiPayload.code.GeneralErrorCode;
+import com.connecteamed.server.global.apiPayload.exception.GeneralException;
+import com.connecteamed.server.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,28 +29,49 @@ import java.util.stream.Collectors;
 public class ContributionService {
     private final ContributionRepository contributionRepository;
     private final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private final SecurityUtil securityUtil;
+    private final ProjectMemberRepository projectMemberRepository;
 
     @Transactional
     public ContributionRes recordContribution(Long userId, Long projectId, ContributionReq request) {
+        System.out.println("=== 기여도 기록 시작 ===");
+        System.out.println("유저ID: " + userId + " | 타겟ID: " + request.targetId());
+
         // 중복 체크
         boolean alreadyExists = contributionRepository.existsByUserIdAndActionTypeAndTargetId(
                 userId, request.actionType(), request.targetId());
 
+        System.out.println("중복 여부: " + alreadyExists);
+
         if (!alreadyExists) {
-            contributionRepository.save(Contribution.builder()
+            Contribution saved = contributionRepository.saveAndFlush(Contribution.builder()
                     .userId(userId)
                     .projectId(projectId)
                     .actionType(request.actionType())
                     .targetId(request.targetId())
                     .build());
+
+            System.out.println("데이터 저장 완료: ID " + saved.getId());
         }
 
         // 오늘의 총 활동 횟수 조회 (DB에서 Instant를 날짜로 변환해 카운트)
         LocalDate today = LocalDate.now(KST);
-        Instant startOfToday = today.atStartOfDay(KST).toInstant();
-        Instant endOfToday = startOfToday.plus(1, ChronoUnit.DAYS);
+        Instant startInstant = today.atStartOfDay(KST).toInstant();
+        Instant endInstant = today.plusDays(1).atStartOfDay(KST).toInstant();
 
-        int todayCount = contributionRepository.countTodayActivities(userId, startOfToday, endOfToday);
+        List<Contribution> todayActivities = contributionRepository.findAllByUserIdAndRange(userId, startInstant, endInstant);
+
+        System.out.println("조회된 리스트 크기: " + todayActivities.size());
+        for(Contribution c : todayActivities) {
+            System.out.println("저장된 데이터 시간: " + c.getCreatedAt() + " | 유저: " + c.getUserId());
+        }
+
+        int todayCount = (int) todayActivities.stream()
+                .filter(c -> c.getCreatedAt().atZone(KST).toLocalDate().equals(today))
+                .count();
+
+        System.out.println("최종 카운트: " + todayCount);
+        System.out.println("=== 기여도 기록 종료 ===");
 
         return new ContributionRes(
                 request.actionType(),
@@ -56,11 +82,18 @@ public class ContributionService {
     }
 
     @Transactional(readOnly = true)
-    public CalendarContributionRes getCalendar(Long userId, int year) {
+    public CalendarContributionRes getCalendar(Long projectId, int year) {
+        Long authId = securityUtil.getCurrentMemberId();
+        ProjectMember pm = projectMemberRepository.findByProject_IdAndMember_Id(projectId, authId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.FORBIDDEN));
+
+        Long realMemberId = pm.getMember().getId();
+        System.out.println("조회 요청 인증ID: " + authId + " -> 실제 변환 ID: " + realMemberId);
+
         Instant startOfYear = LocalDate.of(year, 1, 1).atStartOfDay(KST).toInstant();
         Instant endOfYear = LocalDate.of(year + 1, 1, 1).atStartOfDay(KST).toInstant();
 
-        Map<LocalDate, Long> dbData = contributionRepository.findAllByUserIdAndRange(userId, startOfYear, endOfYear).stream()
+        Map<LocalDate, Long> dbData = contributionRepository.findAllByUserIdAndRange(realMemberId, startOfYear, endOfYear).stream()
                 .collect(Collectors.groupingBy(
                         c -> c.getCreatedAt().atZone(KST).toLocalDate(),
                         Collectors.counting()
@@ -83,7 +116,7 @@ public class ContributionService {
             current = current.plusDays(1);
         }
 
-        return new CalendarContributionRes(year, totalYearlyCount, userId, contributions);
+        return new CalendarContributionRes(year, totalYearlyCount, realMemberId, contributions);
     }
 
     private int calculateLevel(int count) {

--- a/src/main/java/com/connecteamed/server/domain/document/service/DocumentServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/document/service/DocumentServiceImpl.java
@@ -141,11 +141,12 @@ public class DocumentServiceImpl implements DocumentService {
         Project projectRef = projectRepository.getReferenceById(projectId);
 
         ProjectMember projectMember = getProjectMember(projectId, loginId);
+        Long realMemberId = projectMember.getMember().getId();
 
         Document d = Document.createText(projectRef, projectMember, req.title());
         documentRepository.save(d);
 
-        contributionService.recordContribution(projectMember.getMember().getId(), projectId,
+        contributionService.recordContribution(realMemberId, projectId,
                 new ContributionReq(ContributionAction.DOCUMENT_CREATE, d.getId()));
 
         return new DocumentCreateRes(d.getId(), d.getCreatedAt().toString());
@@ -162,6 +163,7 @@ public class DocumentServiceImpl implements DocumentService {
         Project projectRef = projectRepository.getReferenceById(projectId);
 
         ProjectMember projectMember = getProjectMember(projectId, loginId);
+        Long realMemberId = projectMember.getMember().getId();
 
         String fileUrl = s3StorageService.upload(file, "project-" + projectId);
 
@@ -172,7 +174,7 @@ public class DocumentServiceImpl implements DocumentService {
         Document d = Document.createFile(projectRef, projectMember, title, type, fileUrl);
         documentRepository.save(d);
 
-        contributionService.recordContribution(projectMember.getMember().getId(), projectId,
+        contributionService.recordContribution(realMemberId, projectId,
                 new ContributionReq(ContributionAction.DOCUMENT_CREATE, d.getId()));
 
         return new DocumentUploadRes(d.getId(), title, d.getCreatedAt().toString());
@@ -191,7 +193,9 @@ public class DocumentServiceImpl implements DocumentService {
 
         d.updateText(req.title(), req.content());
 
-        contributionService.recordContribution(d.getProjectMember().getMember().getId(), d.getProject().getId(),
+        Long realMemberId = d.getProjectMember().getMember().getId();
+
+        contributionService.recordContribution(realMemberId, d.getProject().getId(),
                 new ContributionReq(ContributionAction.DOCUMENT_UPDATE, d.getId()));
     }
 

--- a/src/main/java/com/connecteamed/server/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/connecteamed/server/domain/meeting/service/MeetingService.java
@@ -77,8 +77,14 @@ public class MeetingService {
         // 마지막에 저장
         Meeting savedMeeting = meetingRepository.save(meeting);
 
-        Long userId = securityUtil.getCurrentMemberId();
-        contributionService.recordContribution(userId, projectId,
+        Long authId = securityUtil.getCurrentMemberId();
+        ProjectMember projectMember = projectMemberRepository.findByProject_IdAndMember_Id(projectId, authId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.FORBIDDEN, "프로젝트 멤버 정보를 찾을 수 없습니다."));
+        Long realMemberId = projectMember.getMember().getId();
+
+        System.out.println("기여도 기록에 사용될 유저 ID: " + realMemberId);
+
+        contributionService.recordContribution(realMemberId, projectId,
                 new ContributionReq(ContributionAction.MEETING_CREATE, savedMeeting.getId()));
 
         return new MeetingCreateRes(savedMeeting.getId(), savedMeeting.getCreatedAt());
@@ -89,12 +95,10 @@ public class MeetingService {
         Meeting meeting = meetingRepository.findByIdAndDeletedAtIsNull(meetingId)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND));
 
-        Long userId = securityUtil.getCurrentMemberId();
-        if (!projectMemberRepository.existsByProjectIdAndMemberId(meeting.getProject().getId(), userId)) {
-            throw new GeneralException(GeneralErrorCode.FORBIDDEN, "회의록 수정 권한이 없습니다.");
-        }
-
-        // 기본 정보 업데이트
+        Long authId = securityUtil.getCurrentMemberId();
+        ProjectMember projectMember = projectMemberRepository.findByProject_IdAndMember_Id(meeting.getProject().getId(), authId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.FORBIDDEN, "회의록 수정 권한이 없습니다."));
+        Long realMemberId = projectMember.getMember().getId();
         meeting.update(request.title(), request.meetingDate());
 
         // 안건 업데이트
@@ -135,7 +139,7 @@ public class MeetingService {
             });
         }
 
-        contributionService.recordContribution(userId, meeting.getProject().getId(),
+        contributionService.recordContribution(realMemberId, meeting.getProject().getId(),
                 new ContributionReq(ContributionAction.MEETING_UPDATE, meeting.getId()));
         return getMeeting(meetingId);
     }

--- a/src/main/java/com/connecteamed/server/domain/project/service/ProjectMemberServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/project/service/ProjectMemberServiceImpl.java
@@ -116,7 +116,8 @@ public class ProjectMemberServiceImpl implements ProjectMemberService {
                 );
             }
         }
-        contributionService.recordContribution(getCurrentUserId(), projectId,
+        Long realMemberId = getCurrentUserId();
+        contributionService.recordContribution(realMemberId, projectId,
                 new ContributionReq(ContributionAction.PROJECT_UPDATE, projectMemberId));
 
         return toRes(pm);

--- a/src/main/java/com/connecteamed/server/domain/project/service/ProjectService.java
+++ b/src/main/java/com/connecteamed/server/domain/project/service/ProjectService.java
@@ -136,7 +136,6 @@ public class ProjectService {
         }
         contributionService.recordContribution(owner.getId(), savedProject.getId(),
                 new ContributionReq(ContributionAction.PROJECT_CREATE, savedProject.getId()));
-
         // 4. 응답 반환
         log.info("[ProjectService] Returning CreateResponse: projectId={}", savedProject.getId());
         return ProjectRes.CreateResponse.builder()
@@ -231,7 +230,8 @@ public class ProjectService {
                 log.debug("[ProjectService] Required role registered: {}", roleName);
             }
         }
-        contributionService.recordContribution(getCurrentUserId(), projectId,
+        Long realMemberId = getCurrentUserId();
+        contributionService.recordContribution(realMemberId, projectId,
                 new ContributionReq(ContributionAction.PROJECT_UPDATE, project.getId()));
 
         // 6. 응답 반환

--- a/src/main/java/com/connecteamed/server/domain/retrospective/service/RetrospectiveService.java
+++ b/src/main/java/com/connecteamed/server/domain/retrospective/service/RetrospectiveService.java
@@ -90,7 +90,8 @@ public class RetrospectiveService {
                 otherTasks
         );
 
-        contributionService.recordContribution(writer.getMember().getId(), projectId,
+        Long realMemberId = writer.getMember().getId();
+        contributionService.recordContribution(realMemberId, projectId,
                 new ContributionReq(ContributionAction.RETROSPECTIVE_CREATE, saved.getId()));
 
         return new RetrospectiveCreateRes(saved.getId(), saved.getTitle());
@@ -131,6 +132,10 @@ public class RetrospectiveService {
         AiRetrospective retrospective = aiRetrospectiveRepository.findByIdAndProjectId(retrospectiveId, projectId)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND));
 
+        ProjectMember projectMember = projectMemberRepository.findByProject_IdAndMember_Id(projectId, memberId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.FORBIDDEN));
+        Long realMemberId = projectMember.getMember().getId();
+
         System.out.println("로그인한 유저 ID (memberId): " + memberId);
         System.out.println("회고 작성자 유저 ID: " + retrospective.getWriter().getMember().getId());
 
@@ -139,7 +144,7 @@ public class RetrospectiveService {
         }
         retrospective.update(request.title(), request.projectResult());
 
-        contributionService.recordContribution(memberId,projectId,
+        contributionService.recordContribution(realMemberId, projectId,
                 new ContributionReq(ContributionAction.RETROSPECTIVE_UPDATE, retrospective.getId()));
     }
 

--- a/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/CompletedTaskService.java
@@ -99,10 +99,10 @@ public class CompletedTaskService {
         Task task = taskRepository.findById(taskId)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND, "해당 ID의 업무를 찾을 수 없습니다."));
 
-        Long currentMemberId = getCurrentUserId();
+        Long realMemberId = getCurrentUserId();
 
         boolean isAssignee = taskAssigneeRepository.findAllByTaskId(taskId).stream()
-                .anyMatch(a -> a.getProjectMember().getMember().getId().equals(currentMemberId));
+                .anyMatch(a -> a.getProjectMember().getMember().getId().equals(realMemberId));
 
         if (!isAssignee) {
             throw new TaskException(TaskErrorCode.TASK_ACCESS_FORBIDDEN, "해당 업무의 담당자가 아니므로 상태를 변경할 수 없습니다.");
@@ -111,7 +111,7 @@ public class CompletedTaskService {
         TaskStatus oldStatus = task.getStatus();
         task.updateStatus(taskStatus);
 
-        contributionService.recordContribution(currentMemberId, task.getProject().getId(),
+        contributionService.recordContribution(realMemberId, task.getProject().getId(),
                 new ContributionReq(ContributionAction.COMPLETED_TASK_UPDATE, taskId));
 
         // 완료한 업무 상태 변경 시 알림 발송
@@ -151,10 +151,10 @@ public class CompletedTaskService {
         Task task = taskRepository.findById(taskId)
                 .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND, "해당 ID의 업무를 찾을 수 없습니다."));
 
-        Long currentMemberId = getCurrentUserId();
+        Long realMemberId = getCurrentUserId();
 
         taskAssigneeRepository.findAllByTaskId(taskId).stream()
-                .filter(a -> a.getProjectMember().getMember().getId().equals(currentMemberId))
+                .filter(a -> a.getProjectMember().getMember().getId().equals(realMemberId))
                 .findFirst()
                 .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_ACCESS_FORBIDDEN, "해당 업무의 담당자가 아니므로 수정할 수 없습니다."));
 
@@ -191,11 +191,11 @@ public class CompletedTaskService {
 
         taskAssigneeRepository.saveAll(newAssignees);
 
-        TaskNote note = taskNoteRepository.findByTaskIdAndTaskAssignee_ProjectMember_Id(taskId, currentMemberId)
-                .orElseGet(() -> createNewNote(task, currentMemberId));
+        TaskNote note = taskNoteRepository.findByTaskIdAndTaskAssignee_ProjectMember_Id(taskId, realMemberId)
+                .orElseGet(() -> createNewNote(task, realMemberId));
         note.updateContent(req.noteContent());
 
-        contributionService.recordContribution(currentMemberId, task.getProject().getId(),
+        contributionService.recordContribution(realMemberId, task.getProject().getId(),
                 new ContributionReq(ContributionAction.COMPLETED_TASK_UPDATE, taskId));
 
         // 완료한 업무 정보 수정 시 알림 발송

--- a/src/main/java/com/connecteamed/server/domain/task/service/TaskServiceImpl.java
+++ b/src/main/java/com/connecteamed/server/domain/task/service/TaskServiceImpl.java
@@ -74,7 +74,8 @@ public class TaskServiceImpl implements TaskService {
         // 알림: 업무 태그
         notificationHelper.sendToAllAssignees(saved, NotificationCategory.TASK_TAGGED);
 
-        contributionService.recordContribution(getCurrentUserId(), projectId,
+        Long realMemberId = getCurrentUserId();
+        contributionService.recordContribution(realMemberId, projectId,
                 new ContributionReq(ContributionAction.TASK_CREATE, saved.getId()));
 
         return saved.getId();
@@ -142,16 +143,15 @@ public class TaskServiceImpl implements TaskService {
         Task task = taskRepository.findByIdAndDeletedAtIsNull(taskId)
                 .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND));
 
-        Long currentMemberId = getCurrentUserId();
-        validateProjectAccess(task.getProject().getId(), currentMemberId);
+        Long realMemberId = getCurrentUserId();
+        validateProjectAccess(task.getProject().getId(), realMemberId);
 
         TaskStatus oldStatus = task.getStatus();
         task.changeStatus(req.status());
 
-        contributionService.recordContribution(currentMemberId, task.getProject().getId(),
+        contributionService.recordContribution(realMemberId, task.getProject().getId(),
                 new ContributionReq(ContributionAction.TASK_UPDATE, taskId));
 
-        // 알림: 다시 진행 중 or 완료
         if (oldStatus == TaskStatus.DONE && req.status() == TaskStatus.IN_PROGRESS) {
             notificationHelper.sendToOthers(task, NotificationCategory.TASK_RESTARTED);
         } else if (req.status() == TaskStatus.DONE) {
@@ -165,7 +165,8 @@ public class TaskServiceImpl implements TaskService {
         Task task = taskRepository.findByIdAndDeletedAtIsNull(taskId)
                 .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND));
 
-        validateProjectAccess(task.getProject().getId(), getCurrentUserId());
+        Long realMemberId = getCurrentUserId();
+        validateProjectAccess(task.getProject().getId(), realMemberId);
 
         if (req.startDate().isAfter(req.dueDate())) {
             throw new TaskException(TaskErrorCode.INVALID_SCHEDULE);
@@ -173,10 +174,9 @@ public class TaskServiceImpl implements TaskService {
 
         task.changeSchedule(req.startDate(), req.dueDate());
 
-        contributionService.recordContribution(getCurrentUserId(), task.getProject().getId(),
+        contributionService.recordContribution(realMemberId, task.getProject().getId(),
                 new ContributionReq(ContributionAction.TASK_UPDATE, taskId));
 
-        // 알림: 업무 내용 수정
         notificationHelper.sendToOthers(task, NotificationCategory.TASK_MODIFIED);
     }
 
@@ -187,7 +187,8 @@ public class TaskServiceImpl implements TaskService {
                 .orElseThrow(() -> new TaskException(TaskErrorCode.TASK_NOT_FOUND));
 
         Long projectId = task.getProject().getId();
-        validateProjectAccess(projectId, getCurrentUserId());
+        Long realMemberId = getCurrentUserId();
+        validateProjectAccess(projectId, realMemberId);
 
         taskAssigneeRepository.deleteAllByTask(task);
         taskAssigneeRepository.flush();
@@ -195,7 +196,7 @@ public class TaskServiceImpl implements TaskService {
         List<Long> assigneeIds = req.assigneeProjectMemberIds() == null ? List.of() : req.assigneeProjectMemberIds();
         attachAssignees(task, projectId, assigneeIds);
 
-        contributionService.recordContribution(getCurrentUserId(), projectId,
+        contributionService.recordContribution(realMemberId, projectId,
                 new ContributionReq(ContributionAction.TASK_UPDATE, taskId));
 
         // 알림: 새로 태그된 사람들에게 알림 발송

--- a/src/test/java/com/connecteamed/server/domain/contribution/service/ContributionServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/contribution/service/ContributionServiceTest.java
@@ -46,7 +46,7 @@ public class ContributionServiceTest {
 
         // then
         assertThat(result.isIncremented()).isTrue();
-        assertThat(result.totalCount()).isEqualTo(1);
+        assertThat(result.todayCount()).isEqualTo(1);
         assertThat(result.currentLevel()).isEqualTo(1); // 1회는 레벨 1
         verify(contributionRepository, times(1)).save(any(Contribution.class));
     }
@@ -69,7 +69,7 @@ public class ContributionServiceTest {
 
         // then
         assertThat(result.isIncremented()).isFalse();
-        assertThat(result.totalCount()).isEqualTo(5);
+        assertThat(result.todayCount()).isEqualTo(5);
         assertThat(result.currentLevel()).isEqualTo(2);
         verify(contributionRepository, never()).save(any(Contribution.class));
     }

--- a/src/test/java/com/connecteamed/server/domain/meeting/service/MeetingServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/meeting/service/MeetingServiceTest.java
@@ -34,6 +34,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -150,7 +151,7 @@ class MeetingServiceTest {
         lenient().when(mockProjectMember.getMember()).thenReturn(mockMember);
         lenient().when(mockMember.getId()).thenReturn(1L);
         lenient().when(mockMember.getName()).thenReturn("테스터");
-        lenient().when(mockProjectMember.getRoles()).thenReturn(List.of()); // roles 리스트 비어있음 설정
+        lenient().when(mockProjectMember.getRoles()).thenReturn(Set.of()); // roles 리스트 비어있음 설정
 
         Meeting existingMeeting = Meeting.builder()
                 .title("기존")

--- a/src/test/java/com/connecteamed/server/domain/notification/service/NotificationCommandServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/notification/service/NotificationCommandServiceTest.java
@@ -1,12 +1,14 @@
 package com.connecteamed.server.domain.notification.service;
 
 import com.connecteamed.server.domain.member.entity.Member;
+import com.connecteamed.server.domain.member.repository.MemberRepository;
 import com.connecteamed.server.domain.notification.entity.Notification;
 import com.connecteamed.server.domain.notification.entity.NotificationType;
 import com.connecteamed.server.domain.notification.enums.NotificationCategory;
 import com.connecteamed.server.domain.notification.repository.NotificationRepository;
 import com.connecteamed.server.domain.notification.repository.NotificationTypeRepository;
 import com.connecteamed.server.domain.project.entity.Project;
+import com.connecteamed.server.domain.project.repository.ProjectRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,7 +32,10 @@ public class NotificationCommandServiceTest {
     private NotificationRepository notificationRepository;
 
     @Mock
-    private NotificationTypeRepository notificationTypeRepository;
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ProjectRepository projectRepository;
 
     @InjectMocks
     private NotificationCommandService notificationCommandService;
@@ -39,21 +44,20 @@ public class NotificationCommandServiceTest {
     @DisplayName("알림 생성 및 저장 성공 테스트")
     void send_Notification_Success() {
         // given
-        Member receiver = Member.builder().id(1L).build();
-        Member sender = Member.builder().id(2L).build();
-        Project project = Project.builder().id(100L).name("Connected").build();
+        Long receiverId = 1L;
+        Long senderId = 2L;
+        Long projectId = 100L;
         Long taskId = 50L;
         NotificationCategory category = NotificationCategory.TASK_TAGGED;
 
-        NotificationType mockType = NotificationType.builder()
-                .typeKey(category.name())
-                .build();
+        Member receiver = Member.builder().id(receiverId).build();
+        Project project = Project.builder().id(projectId).name("Connected").build();
 
-        when(notificationTypeRepository.findByTypeKey(category.name()))
-                .thenReturn(Optional.of(mockType));
+        when(memberRepository.findById(receiverId)).thenReturn(Optional.of(receiver));
+        when(projectRepository.findById(projectId)).thenReturn(Optional.of(project));
 
         // when
-        notificationCommandService.send(receiver, sender, project, taskId, category.name());
+        notificationCommandService.send(receiverId, senderId, projectId, taskId, category.name());
 
         // then
         ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
@@ -61,7 +65,9 @@ public class NotificationCommandServiceTest {
         Notification savedNotification = captor.getValue();
 
         assertThat(savedNotification.getReceiver()).isEqualTo(receiver);
+        assertThat(savedNotification.getProject()).isEqualTo(project);
+        assertThat(savedNotification.getCategory()).isEqualTo(category);
         assertThat(savedNotification.getContent()).isEqualTo(category.getMessage());
-        assertThat(savedNotification.getTargetUrl()).isEqualTo(category.generateUrl(100L, 50L));
+        assertThat(savedNotification.getTargetUrl()).isEqualTo(category.generateUrl(projectId, taskId));
     }
 }

--- a/src/test/java/com/connecteamed/server/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/notification/service/NotificationServiceTest.java
@@ -62,7 +62,7 @@ public class NotificationServiceTest {
                 .id(1L)
                 .receiver(Member.builder().loginId(loginId).build())
                 .project(project)
-                .notificationType(type)
+                .category(category)
                 .content(category.getMessage())
                 .targetUrl(category.generateUrl(projectId, taskId))
                 .isRead(false)
@@ -86,8 +86,8 @@ public class NotificationServiceTest {
 
         // 상세 필드 검증
         var res = result.notifications().get(0);
-        assertThat(res.teamName()).isEqualTo("테스트 프로젝트");
-        assertThat(res.message()).isEqualTo(category.getMessage());
+        assertThat(res.title()).isEqualTo("테스트 프로젝트");
+        assertThat(res.content()).isEqualTo(category.getMessage());
         assertThat(res.targetUrl()).isEqualTo("/projects/100/tasks/50");
         assertThat(res.notificationType()).isEqualTo("TASK_TAGGED");
     }


### PR DESCRIPTION
## 📌 PR 요약
- 잔디 누락 오류를 수정했습니다.

## 🔧 변경 사항
- 잔디 호출 시 전달되는 유저 ID를 ProjectMember의 식별자가 아닌 실제 Member 엔티티의 PK로 통일하여 데이터 정합성을 확보했습니다.

## 📋 작업 상세 내용
- [x] ContributionService 연동 및 Member ID 전달 로직 수정
- [x] 미선언 변수 참조 오류(userId -> authId) 수정

## 🔗 관련 이슈
- closed #102 