### PR TITLE
[FEAT] 대시보드에 teamId 추가

### DIFF
--- a/src/main/java/com/connecteamed/server/domain/dashboard/dto/DailyScheduleListRes.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/dto/DailyScheduleListRes.java
@@ -9,6 +9,7 @@ public record DailyScheduleListRes (
 ) {
     public record ScheduleRes (
             Long id,
+            Long teamId,
             String title,
             String teamName,
             Instant time

--- a/src/main/java/com/connecteamed/server/domain/dashboard/dto/DashboardRes.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/dto/DashboardRes.java
@@ -33,9 +33,9 @@ public class DashboardRes {
         @Schema(description = "회고 ID", example = "101")
         private Long id;
 
-        @JsonProperty("projectId")
-        @Schema(description = "프로젝트 ID", example = "1")
-        private Long projectId;
+        @JsonProperty("teamId")
+        @Schema(description = "팀(프로젝트) ID", example = "1")
+        private Long teamId;
 
         @JsonProperty("title")
         @Schema(description = "회고 제목", example = "회고 제목입니다")

--- a/src/main/java/com/connecteamed/server/domain/dashboard/dto/NotificationListRes.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/dto/NotificationListRes.java
@@ -8,6 +8,7 @@ public record NotificationListRes (
 ) {
     public record NotificationRes (
             Long id,
+            Long teamId,
             String message,
             String teamName,
             boolean isRead,

--- a/src/main/java/com/connecteamed/server/domain/dashboard/dto/UpcomingTaskListRes.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/dto/UpcomingTaskListRes.java
@@ -10,6 +10,7 @@ public record UpcomingTaskListRes (
 ) {
     public record UpcomingTaskRes (
             Long id,
+            Long teamId,
             String title,
             TaskStatus status,
             String teamName,

--- a/src/main/java/com/connecteamed/server/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/connecteamed/server/domain/dashboard/service/DashboardService.java
@@ -71,6 +71,7 @@ public class DashboardService {
         List<UpcomingTaskListRes.UpcomingTaskRes> taskResList = tasks.stream()
                 .map(task -> new UpcomingTaskListRes.UpcomingTaskRes(
                         task.getId(),
+                        task.getProject().getId(),
                         task.getName(),
                         task.getStatus(),
                         task.getProject().getName(),
@@ -87,6 +88,7 @@ public class DashboardService {
         List<NotificationListRes.NotificationRes> resList = notifications.stream()
                 .map(n -> new NotificationListRes.NotificationRes(
                         n.getId(),
+                        n.getProject().getId(),
                         n.getContent(),
                         n.getProject().getName(),
                         n.isRead(),
@@ -113,6 +115,7 @@ public class DashboardService {
         // 업무 추가
         dailyTasks.forEach(t -> resList.add(new DailyScheduleListRes.ScheduleRes(
                 t.getId(),
+                t.getProject().getId(),
                 "[업무] " + t.getName(),
                 t.getProject().getName(),
                 t.getDueDate()
@@ -121,6 +124,7 @@ public class DashboardService {
         // 회의 추가
         dailyMeetings.forEach(m -> resList.add(new DailyScheduleListRes.ScheduleRes(
                 m.getId(),
+                m.getProject().getId(),
                 "[회의] " + m.getTitle(),
                 m.getProject().getName(),
                 m.getMeetingDate()
@@ -141,7 +145,7 @@ public class DashboardService {
         List<DashboardRes.RetrospectiveInfo> retrospectiveInfos = retrospectives.stream()
                 .map(retrospective -> DashboardRes.RetrospectiveInfo.builder()
                         .id(retrospective.getId())
-                        .projectId(retrospective.getProject().getId())
+                        .teamId(retrospective.getProject().getId())
                         .title(retrospective.getTitle())
                         .teamName(retrospective.getProject().getName())
                         .writtenDate(retrospective.getCreatedAt().atZone(ZoneId.systemDefault()).toLocalDate())

--- a/src/main/java/com/connecteamed/server/domain/notification/dto/NotificationRes.java
+++ b/src/main/java/com/connecteamed/server/domain/notification/dto/NotificationRes.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 @Builder
 public record NotificationRes (
         Long id,
+        Long teamId,
         String notificationType,
         String title,
         String content,

--- a/src/main/java/com/connecteamed/server/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/connecteamed/server/domain/notification/service/NotificationService.java
@@ -52,6 +52,7 @@ public class NotificationService {
     private NotificationRes convertToResponse(Notification notification) {
         return NotificationRes.builder()
                 .id(notification.getId())
+                .teamId(notification.getProject().getId())
                 .notificationType(notification.getCategory().name())
                 .title(notification.getProject().getName())
                 .content(notification.getContent())

--- a/src/test/java/com/connecteamed/server/domain/dashboard/service/DashboardServiceIntegrationTest.java
+++ b/src/test/java/com/connecteamed/server/domain/dashboard/service/DashboardServiceIntegrationTest.java
@@ -10,6 +10,7 @@ import com.connecteamed.server.domain.meeting.entity.Meeting;
 import com.connecteamed.server.domain.meeting.repository.MeetingRepository;
 import com.connecteamed.server.domain.notification.entity.Notification;
 import com.connecteamed.server.domain.notification.entity.NotificationType;
+import com.connecteamed.server.domain.notification.enums.NotificationCategory;
 import com.connecteamed.server.domain.notification.repository.NotificationRepository;
 import com.connecteamed.server.domain.project.entity.Project;
 import com.connecteamed.server.domain.project.entity.ProjectMember;
@@ -131,7 +132,7 @@ public class DashboardServiceIntegrationTest {
                 .content("새로운 알림")
                 .targetUrl("/test")
                 .isRead(false)
-                .notificationType(type)
+                .category(NotificationCategory.TASK_TAGGED)
                 .build());
 
         // When: 서비스 호출

--- a/src/test/java/com/connecteamed/server/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/connecteamed/server/domain/notification/service/NotificationServiceTest.java
@@ -62,7 +62,7 @@ public class NotificationServiceTest {
                 .id(1L)
                 .receiver(Member.builder().loginId(loginId).build())
                 .project(project)
-                .notificationType(type)
+                .category(NotificationCategory.TASK_TAGGED)
                 .content(category.getMessage())
                 .targetUrl(category.generateUrl(projectId, taskId))
                 .isRead(false)
@@ -86,8 +86,8 @@ public class NotificationServiceTest {
 
         // 상세 필드 검증
         var res = result.notifications().get(0);
-        assertThat(res.teamName()).isEqualTo("테스트 프로젝트");
-        assertThat(res.message()).isEqualTo(category.getMessage());
+        assertThat(res.title()).isEqualTo("테스트 프로젝트");
+        assertThat(res.content()).isEqualTo(category.getMessage());
         assertThat(res.targetUrl()).isEqualTo("/projects/100/tasks/50");
         assertThat(res.notificationType()).isEqualTo("TASK_TAGGED");
     }


### PR DESCRIPTION
## 📌 PR 요약
- 대시보드 로직에 teamId를 추가했습니다.

## 🔧 변경 사항
- 대시보드에 할당된 업무 등을 클릭 시 해당 페이지로 안전히 이동할 수 있도록 teamId를 추가했습니다.

## 📋 작업 상세 내용
- [x] DashboardRes 및 DashboardService에 teamId 추가